### PR TITLE
suggesting revisions to background info section

### DIFF
--- a/doc/read-the-docs-site/background/cc-credentials.rst
+++ b/doc/read-the-docs-site/background/cc-credentials.rst
@@ -25,7 +25,7 @@ The purpose of querying the committee state includes the following:
 Typically done by the Orchestrator role
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Typically, someone in the Orchestrator role would be querying the current committee state. 
+Typically, someone in the orchestrator role would be querying the current committee state. 
 The Orchestrator is one of the operational roles within the Constitutional Committee Credential Management System. 
 
 The orchestrator role requires a deep understanding of the credential management system and the ability to execute commands using the Cardano CLI. 

--- a/doc/read-the-docs-site/background/cc-credentials.rst
+++ b/doc/read-the-docs-site/background/cc-credentials.rst
@@ -17,10 +17,10 @@ It is technical step performed to interact with and verify the state of the bloc
 
 The purpose of querying the committee state includes the following: 
 
-- **Checking membership:** By querying the committee state, you can verify which members are currently part of the committee by checking their cold credentials.
-- **Confirming credential status:** It allows you to check the status of both hot and cold credentials, such as whether a hot credential is authorized to vote on behalf of a cold credential.
-- **Validating changes:** After performing certain actions, like authorizing a hot credential or submitting a resignation, querying the state helps confirm that these changes have taken effect on-chain.
-- **Monitoring expiration:** The query can show you the expiration of credentials, which is crucial for maintaining active participation in the committee's activities.
+- **Checking membership.** By querying the committee state, you can verify which members are currently part of the committee by checking their cold credentials.
+- **Confirming credential status.** It allows you to check the status of both hot and cold credentials, such as whether a hot credential is authorized to vote on behalf of a cold credential.
+- **Validating changes.** After performing certain actions, like authorizing a hot credential or submitting a resignation, querying the state helps confirm that these changes have taken effect on-chain.
+- **Monitoring expiration.** The query can show you the expiration of credentials, which is crucial for maintaining active participation in the committee's activities.
 
 Typically done by the Orchestrator role
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/read-the-docs-site/background/cc-credentials.rst
+++ b/doc/read-the-docs-site/background/cc-credentials.rst
@@ -22,7 +22,7 @@ The purpose of querying the committee state includes the following:
 - **Validating changes.** After performing certain actions, like authorizing a hot credential or submitting a resignation, querying the state helps confirm that these changes have taken effect on-chain.
 - **Monitoring expiration.** The query can show you the expiration of credentials, which is crucial for maintaining active participation in the committee's activities.
 
-Typically done by the Orchestrator role
+Typically done by the orchestrator role
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Typically, someone in the orchestrator role would be querying the current committee state. 

--- a/doc/read-the-docs-site/background/cc-credentials.rst
+++ b/doc/read-the-docs-site/background/cc-credentials.rst
@@ -28,7 +28,7 @@ Typically done by the Orchestrator role
 Typically, someone in the Orchestrator role would be querying the current committee state. 
 The Orchestrator is one of the operational roles within the Constitutional Committee Credential Management System. 
 
-The Orchestrator role requires a deep understanding of the Credential Manager system and the ability to execute commands using the Cardano CLI. 
+The orchestrator role requires a deep understanding of the credential management system and the ability to execute commands using the Cardano CLI. 
 
 Cold credentials
 ----------------

--- a/doc/read-the-docs-site/background/cc-credentials.rst
+++ b/doc/read-the-docs-site/background/cc-credentials.rst
@@ -26,7 +26,7 @@ Typically done by the Orchestrator role
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Typically, someone in the orchestrator role would be querying the current committee state. 
-The Orchestrator is one of the operational roles within the Constitutional Committee Credential Management System. 
+The orchestrator is one of the operational roles within the Constitutional Committee credential management system. 
 
 The orchestrator role requires a deep understanding of the credential management system and the ability to execute commands using the Cardano CLI. 
 

--- a/doc/read-the-docs-site/background/cc-credentials.rst
+++ b/doc/read-the-docs-site/background/cc-credentials.rst
@@ -1,18 +1,42 @@
 .. _cc_credentials:
 
-Constitutional Committee Credentials
-====================================
+Balancing security and accessibility with cold and hot credentials
+==================================================================
 
-Having covered credentials in general, let's take a closer look at
-Constitutional Committee credentials. Members of the constitutional committee
-have two credentials to manage: a cold credential and a hot credential.
+Constitutional Committee members maintain operational integrity by managing two credentials: a cold credential and a hot credential.
 
-Cold Credentials
+One of the purposes of this credential management system is to provide multiple layers of security to help committee members prevent losing control over a cold credential and to give good options for recovery if necessary. 
+
+Before looking more closely at details, let's briefly put this discussion into a practical context. 
+
+Querying the committee state
+-------------------------------------------
+
+Querying the current committee state from a Cardano node is a standard procedure for those involved in the governance and maintenance of the Cardano network. 
+It is technical step performed to interact with and verify the state of the blockchain regarding committee membership and credential status. 
+
+The purpose of querying the committee state includes the following: 
+
+- **Checking membership:** By querying the committee state, you can verify which members are currently part of the committee by checking their cold credentials.
+- **Confirming credential status:** It allows you to check the status of both hot and cold credentials, such as whether a hot credential is authorized to vote on behalf of a cold credential.
+- **Validating changes:** After performing certain actions, like authorizing a hot credential or submitting a resignation, querying the state helps confirm that these changes have taken effect on-chain.
+- **Monitoring expiration:** The query can show you the expiration of credentials, which is crucial for maintaining active participation in the committee's activities.
+
+Typically done by the Orchestrator role
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Typically, someone in the Orchestrator role would be querying the current committee state. 
+The Orchestrator is one of the operational roles within the Constitutional Committee Credential Management System. 
+
+The Orchestrator role requires a deep understanding of the Credential Manager system and the ability to execute commands using the Cardano CLI. 
+
+Cold credentials
 ----------------
 
-The cold credential is used to identify committee members, and can be thought
-of as a sort of "primary" credential. The cold credential is what you see if
-you query the current committee state from a Cardano node:
+Given that context, let's take a closer look at some details about the cold credential. 
+
+Think of the cold credential as a "primary" credential that's used for identifying committee members. 
+The cold credential is what the Orchestrator sees from the command line when querying the current committee state from a Cardano node:
 
 .. code-block:: bash
 
@@ -34,51 +58,44 @@ you query the current committee state from a Cardano node:
       "threshold": 0.67
    }
 
-This example shows a committee with one member identified by the cold
-credential ``keyHash-5e86313210aef13297187c38c98abb632678906230f555a1bf0a647a``.
-The cold credential is used to authorize transactions that publish two types of
-certificates:
+This example shows a committee with one member identified by the cold credential ``keyHash-5e86313210aef13297187c38c98abb632678906230f555a1bf0a647a``.
+Note the tag: ``MemberNotAuthorized``.
 
-1. Hot credential authorization certificates, which have the effect of
-   registering a hot credential to vote on behalf of the cold credential.
-2. Committee resignation certificates, which have the effect of removing the
-   member from the committee.
+Authorizing transactions that publish two types of certificates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Both of these are exceptional events which should occur infrequently, if at all
-(a hot credential must be authorized at least once to allow for voting).
+The cold credential is used to authorize transactions that publish two types of certificates:
 
-A cold credential can be added to the committee in one of two ways:
+1. Hot credential authorization certificates, which have the effect of registering a hot credential to vote on behalf of the cold credential.
+2. Committee resignation certificates, which have the effect of removing the member from the committee.
 
-1. A governance action proposing to add it to the committee is ratified and
-   enacted.
-2. It is hard-coded in the Conway Genesis configuration file.
+Both of these are exceptional events which should occur infrequently, if at all, although a hot credential must be authorized at least once to allow for voting.
 
-Both of these processes are beyond the control of the bearer of the cold
-credential. In the first case, it is up to the electorate (DReps and SPOs) of
-Cardano whether or not the governance action is ratified. In the second case,
-there is only one Conway Genesis file, and it cannot be altered (though in
-theory new committee members *could* be injected in a subsequent hard-fork
-event, though this is highly unlikely, and would still be subject to approval
-from the DReps and SPOs).
+Two ways to add a cold credential to a committee 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This makes the cold credential extremely security critical, as losing control
-over it can only be remedied by the member being voted out of the committee in
-the best case, or the entire committee being disbanded via a no confidence
-governance action in the worst case. Either way, the member is unlikely to be
-re-elected after such a display of negligence. One of the purposes of this
-credential management system is to provide additional layers of security which
-help prevent this sort of situation and give better options for recovery if
-necessary.
+A cold credential can be added to the committee in one of two ways, both of which are beyond the control of the one who holds the cold credential. 
 
-Hot Credentials
+1. Ratifying and enacting a governance action that proposes to add a cold credential to the committee. The electorate (DReps and SPOs) of Cardano determine whether or not to ratify governance actions. 
+
+2. Hard-coding a cold credential in the Conway Genesis configuration file. There is only one Conway Genesis file, and it cannot be altered. 
+
+Cold credential is extremely security critical
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This makes the cold credential extremely security critical, as losing control over it can only be remedied by the member being voted out of the committee in the best case, or the entire committee being disbanded via a no confidence governance action in the worst case. 
+Either way, the member is unlikely to be re-elected after such a display of negligence. 
+
+Hot credentials
 ---------------
 
-The hot credential is required to vote as a committee member. It is the
-"workhorse" credential, in that it is expected to be used frequently for
-everyday business. This is in contrast to the cold credential, which is expected
-to be used only in exceptional circumstances. A hot credential must be
-authorized by the cold credential, and also appears in the committee state
-queried from a Cardano node:
+For a committee member to be authorized to vote, they must have a hot credential. 
+It is the "workhorse" credential, in that it is expected to be used frequently for everyday business. 
+
+This is in contrast to the cold credential, which is expected to be used infrequently and only in exceptional circumstances. 
+
+A hot credential must be authorized by the cold credential. 
+It also appears in the committee state queried from a Cardano node:
 
 .. code-block:: bash
 
@@ -103,47 +120,22 @@ queried from a Cardano node:
       "threshold": 0.67
    }
 
-This example shows the same committee member as before, only this time they
-have authorized a hot credential, namely
-``{ "keyHash": "e394a160b9f1345b7b84cd25f0a3f1d12cb0c9835a4167f7dc5b52ca" }``.
+This example shows the same committee member as before, only this time they have authorized a hot credential, namely
+``{ "keyHash": "e394a160b9f1345b7b84cd25f0a3f1d12cb0c9835a4167f7dc5b52ca" }``. 
+Note the tag: ``MemberAuthorized``.
 
-Compared with the cold credential, a hot credential is relatively cheap to
-replace: when a new hot credential is authorized by the cold credential, it
-invalidates the existing hot credential, taking its place. This is entirely
-within the control of the bearer of the cold credential, and comes into effect
-as soon as the authorization certificate is published on chain via a
-transaction. That notwithstanding, it is still undesirable to replace the hot
-credential if it can be avoided. This is because doing so requires using the
-cold credential, which is meant to be used sparingly - ideally never after the
-hot credential is authorized. Replacing hot credentials frequently is also
-highly visible activity and may negatively impact the reputation of the
-committee member within the community - remember, the community has the power
-to depose individual committee members or the whole committee if they lose
-faith in them. This system also offers greater flexibility for managing the hot
-credential without having to replace it.
+Replaceable 
+~~~~~~~~~~~~
 
-Note on Terminology
--------------------
+Compared with the cold credential, a hot credential is relatively cheap to replace: when a new hot credential is authorized by the cold credential, it invalidates the existing hot credential, taking its place. 
+This is entirely within the control of the bearer of the cold credential, and comes into effect as soon as the authorization certificate is published on chain via a transaction. 
 
-The names "hot" and "cold" come from the terms "hot key" and "cold key". A cold
-key is a key that is only used to authorize a hot key to act on its behalf, but
-is otherwise kept in "cold storage" (e.g. on a computer physically separated
-from the internet, or a non-digital medium) for security purposes. The hot
-credential is used to conduct everyday business, and may be kept in "hot" or
-"live" storage so that it is easier to access. The benefit of such a setup is
-that it offers many of the security benefits of keeping keys in cold storage
-while mitigating the drawbacks of doing so - namely it is not convenient to use
-the cold key frequently.
+Drawbacks of replacing hot credentials
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Analogously, the cold committee credential is used only for hot credential
-authorization and committee resignation, both of which are exceptional
-activities, while the hot credential is used for everyday LOB work. Indeed, if
-public key credentials are used for both, the analogy is perfect. However, the
-analogy breaks down somewhat when script credentials are used, as there is no
-notion of keeping private keys in hot or cold storage with script credentials.
-The concept is still applicable though: The cold credential is used rarely, the
-hot credential is used often. Therefore, any private data needed to activate
-the cold credential should be treated like a cold private key and kept in cold
-storage. For example, if the cold credential requires the transaction to be
-signed by multiple private keys, as is the case with this system, those private
-keys should be treated like cold keys, because that is what they are.
+Replacing a hot credential requires using the cold credential, which is meant to be used sparingly --- ideally never after the hot credential is authorized. 
+
+Replacing hot credentials frequently is a highly visible activity and may negatively impact the reputation of the committee member within the community. 
+Remember, the community has the power to depose individual committee members or the whole committee if they lose faith in them. 
+
+This system also offers greater flexibility for managing the hot credential without having to replace it.

--- a/doc/read-the-docs-site/background/cc-credentials.rst
+++ b/doc/read-the-docs-site/background/cc-credentials.rst
@@ -90,7 +90,7 @@ Hot credentials
 ---------------
 
 For a committee member to be authorized to vote, they must have a hot credential. 
-It is the "workhorse" credential, in that it is expected to be used frequently for everyday business. 
+It is the 'workhorse' credential as it is expected to be used frequently for everyday business. 
 
 This is in contrast to the cold credential, which is expected to be used infrequently and only in exceptional circumstances. 
 

--- a/doc/read-the-docs-site/background/cc-credentials.rst
+++ b/doc/read-the-docs-site/background/cc-credentials.rst
@@ -36,7 +36,7 @@ Cold credentials
 Given that context, let's take a closer look at some details about the cold credential. 
 
 Think of the cold credential as a "primary" credential that's used for identifying committee members. 
-The cold credential is what the Orchestrator sees from the command line when querying the current committee state from a Cardano node:
+The cold credential is what the orchestrator sees from the command line when querying the current committee state from a Cardano node:
 
 .. code-block:: bash
 

--- a/doc/read-the-docs-site/background/cc-credentials.rst
+++ b/doc/read-the-docs-site/background/cc-credentials.rst
@@ -76,7 +76,7 @@ Two ways to add a cold credential to a committee
 
 A cold credential can be added to the committee in one of two ways, both of which are beyond the control of the one who holds the cold credential. 
 
-1. Ratifying and enacting a governance action that proposes to add a cold credential to the committee. The electorate (DReps and SPOs) of Cardano determine whether or not to ratify governance actions. 
+1. Ratifying and enacting a governance action that proposes to add a cold credential to the committee. The electorate – Cardano's delegate representatives (DReps) and stake pool operators (SPOs) – determine whether or not to ratify governance actions. 
 
 2. Hard-coding a cold credential in the Conway Genesis configuration file. There is only one Conway Genesis file, and it cannot be altered. 
 

--- a/doc/read-the-docs-site/background/cc-credentials.rst
+++ b/doc/read-the-docs-site/background/cc-credentials.rst
@@ -78,7 +78,7 @@ A cold credential can be added to the committee in one of two ways, both of whic
 
 1. Ratifying and enacting a governance action that proposes to add a cold credential to the committee. The electorate – Cardano's delegate representatives (DReps) and stake pool operators (SPOs) – determine whether or not to ratify governance actions. 
 
-2. Hard-coding a cold credential in the Conway Genesis configuration file. There is only one Conway Genesis file, and it cannot be altered. 
+2. Hard-coding a cold credential in the Conway genesis configuration file. There is only one Conway genesis file, and it cannot be altered. 
 
 Cold credential is extremely security critical
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/read-the-docs-site/background/credentials.rst
+++ b/doc/read-the-docs-site/background/credentials.rst
@@ -67,7 +67,7 @@ Script credentials
 -------------------
 
 Script credentials are executable programs that encode custom authorization rules. 
-These are also informally referred to as "smart contracts." 
+These are also informally referred to as 'smart contracts.'
 To authorize a transaction, the smart contract receives a summary of the transaction it is authorizing and executes it. 
 If the program terminates without raising an exception, it is considered to have authorized the transaction. 
 

--- a/doc/read-the-docs-site/background/credentials.rst
+++ b/doc/read-the-docs-site/background/credentials.rst
@@ -9,7 +9,7 @@ Credentials are used for many purposes in the Conway era, including:
 * Consuming UTXOs
 * Withdrawing staking rewards
 * Publishing governance certificates
-* Voting
+* Voting.
 
 There are two types of credentials: 
 

--- a/doc/read-the-docs-site/background/credentials.rst
+++ b/doc/read-the-docs-site/background/credentials.rst
@@ -1,89 +1,101 @@
 .. _cardano_credentials:
 
-Cardano Credentials
-===================
+Public key credentials versus script credentials 
+================================================
 
-On Cardano, a credential is a piece of information that anyone can use to
-verify the legitimacy of changes to the blockchain described by a transaction.
+On Cardano, anyone can verify the legitimacy of a transaction on the blockchain by using a credential. 
 Credentials are used for many purposes in the Conway era, including:
 
-* Consuming UTxOs (Payment credentials)
-* Withdrawing staking rewards (staking credentials)
-* Publishing governance certificates (DRep, Cold Committee credentials)
-* Voting (DRep, Hot Committee credentials)
+* Consuming UTxOs
+* Withdrawing staking rewards
+* Publishing governance certificates
+* Voting
 
-There are two types of credentials: public key credentials and script
-credentials.
+There are two types of credentials: 
 
-Public Key Credentials
-----------------------
+1. Public key credentials, and 
+2. Script credentials.
 
-Public Key Credentials use
-`public-key cryptography <https://en.wikipedia.org/wiki/Public-key_cryptography>`_
-to prove that transactions were authorized by the appropriate parties. If a
-transaction requires authorization from the bearer of a public key credential,
-it must be **signed** by them. To sign a transaction, the owner of the public
-key attaches a **signature** to the transaction. A signature is a cryptographic
-digest of the transaction produced using the public key's associated **private
-key**. The signature proves that the transaction was witnessed by the
-credential owner, and the public key can be used by anyone to verify the
-signature. There are several advantages to public key credentials:
+Public key credentials
+------------------------
 
-* They are easy to create
-* Provided that a secure source of randomness was used to generate the key
-  pair, and that the private key is managed securely, they provide quite good
-  security without much room for exploitation.
-* They are cheap to verify and small in size, all of which lowers transaction
-  fees significantly compared with script credentials.
+Public key credentials use `public-key cryptography <https://en.wikipedia.org/wiki/Public-key_cryptography>`_ to prove that the appropriate party or parties have authorized a transaction. Public-key cryptography involves a pair of keys: 
+
+* A **public key**, which can be shared openly, and 
+* A **private key**, which must be kept secret.
+
+When a transaction needs to be authorized by someone who holds a **public key credential**, that person must sign the transaction by generating a cryptographic signature using their private key and attaching that signature to the transaction. 
+
+A signature is a cryptographic digest of the transaction that is produced using the public key's associated private key. This digest, or signature, uniquely represents the transaction and the private key used to sign it.
+
+The signature attached to the transaction proves that the transaction was authorized by the owner of the public key credential. Because the private key is kept secret, only the owner of the corresponding private key could have generated the signature.
+
+Anyone can use the public key to verify the signature. During verification, the public key is used to decrypt the signature, producing a digest. If this digest matches a freshly generated digest of the transaction, it confirms that the signature was created using the corresponding private key and that the transaction has not been tampered with. 
+
+Advantages of public key credentials
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are a number of advantages to public key credentials:
+
+* They are easy to create. 
+* They provide quite good security without much room for exploitation, provided that a secure source of randomness was used to generate the key pair, and that the private key is managed securely. 
+* They are cheap to verify and small in size, all of which lowers transaction fees significantly compared with script credentials.
 * They are based on a mature and standard cryptographic algorithm (Ed25519).
+
+Disadvantages of public key credentials
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 However, they also have drawbacks:
 
 * They are single points of failure. If the private key is lost or stolen, the
-  legitimate owner of the credential will be unable to authorize transactions,
-  nor will they be able to stop thieves from impersonating them.
-* They are not sufficient for setups requiring authorization from multiple
+  legitimate owner of the credential will be unable to authorize transactions or
+  stop thieves from impersonating them.
+* They are not sufficient for circumstances requiring authorization from multiple
   individuals.
-* They are opaque on their own - they do not contain identifiable information.
+* They are opaque on their own --- they do not contain identifiable information.
   Depending on the application, this can also be an advantage, but not when
-  transparency is desired.
+  transparency is important.
 * They may be difficult to change if a credential is compromised. For example,
   all UTxOs owned by a payment key would need to be sent to the new one,
   costing the owner ADA in fees. Other types of credentials, particularly
   constitutional committee cold credentials, are far more difficult to change.
 
-All of these drawbacks make public key credentials generally inappropriate for
-organizations which distribute and delegate authority to staff or other
-types of trustees.
+All of these drawbacks make public key credentials generally inappropriate for organizations that 
+distribute and delegate authority to staff or other types of trustees.
 
-Script Credentials
-------------------
+Script credentials
+-------------------
 
-Script credentials are executable programs which encode custom authorization
-rules. These are also informally referred to as "smart contracts." To authorize
-a transaction, the program receives a summary of the transaction it is
-authorizing and is executed. If the program terminates without raising an
-exception, it is considered to have authorized the transaction. Though there
-are many scripting languages which target Cardano, fundamentally there are only
-two types of script credentials: native scripts and Plutus scripts. Native
-scripts are able to enforce simple rules such as requiring signatures,
-enforcing time limits, and conjunctive and disjunctive combinations thereof,
-i.e. "all of" and "any of" combinations, respectively. Plutus scripts are
-programs compiled to Untyped Plutus Core, a low-level variant of lambda
-calculus which serves as a compilation target for other higher level scripting
-languages such as PlutusTx or Aiken.
+Script credentials are executable programs that encode custom authorization rules. 
+These are also informally referred to as "smart contracts." 
+To authorize a transaction, the smart contract receives a summary of the transaction it is authorizing and executes it. 
+If the program terminates without raising an exception, it is considered to have authorized the transaction. 
 
-As an example, a script can be used to control how a UTxO is spent. The UTxO
-is held by an address containing the script's payment credential, which is a
-cryptographic hash of the script's serialized representation. It is also held
-alongside a piece of data which can be used to represent the "state" of the
-script. To spend the UTxO, the spending transaction must include the actual
-script bytes, either directly or via a reference to a script stored elsewhere
-on chain. The transaction can also provide an argument to the script, called a
-*redeemer*. The script is then executed with the datum held in the UTxO, the
-redeemer provided in the spending transaction, and a summary of the spending
-transaction, called the *script context*. If it executes without raising an
-exception, the UTxO is authorized for being spent.
+Native scripts and Plutus scripts 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Though many scripting languages target Cardano, there are only two types of script credentials: native scripts and Plutus scripts. 
+
+* **Native scripts** --- With native scripts, you can set up simple rules like requiring signatures, setting deadlines, and combining conditions using 'all of' or 'any of' options. 
+
+* **Plutus scripts** --- Plutus scripts are programs compiled to Untyped Plutus Core, a low-level variant of lambda calculus, that serves as a compilation target for other higher-level scripting languages such as PlutusTx or Aiken.
+
+Description of a Plutus script example 
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+As an example, a Plutus script can be used to control how a UTxO is spent. 
+
+The UTxO is held by an address containing the script's payment credential, which is a cryptographic hash of the script's serialized representation. 
+It is also held alongside a piece of data (the *datum*) which can be used to represent the "state" of the script. 
+
+To spend the UTxO, the spending transaction must include the actual script bytes, either directly or via a reference to a script stored elsewhere on chain. 
+The transaction can also provide an argument to the script, called a *redeemer*. 
+The script is then executed with the datum held in the UTxO, the redeemer provided in the spending transaction, and a summary of the spending transaction, called the *script context*. 
+
+If it executes without raising an exception, the UTxO is authorized for being spent.
+
+Benefits of script credentials
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Script credentials offer many benefits over public key credentials:
 
@@ -93,14 +105,17 @@ Script credentials offer many benefits over public key credentials:
 * Via the datum, they can be associated with supplemental information, which
   can be used for identity verification.
 * They can have failsafe options built into them to allow recovery of the credential
-  if auxillary data such as private keys are compromised.
+  if auxillary data, such as private keys, are compromised.
+
+Disadvangates of script credentials
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 However, they also have several disadvantages:
 
-* They are complicated and expensive to create and used compared with public
+* They are complicated and expensive to create and use compared with public
   key credentials.
 * If they are not carefully written and tested, there can be unintended edge
-  cases or bugs which compromise their security.
+  cases or bugs that compromise their security.
 * Between the script bytes, the datum and the redeemer, they consume a lot of
   space in transactions, and are expensive to validate compared with public
   keys and signatures. This makes them more expensive, as these factors
@@ -109,7 +124,9 @@ However, they also have several disadvantages:
 Ultimately, script credentials can solve many of the shortcomings of public key
 credentials, but they do so at a cost. They can require significant upfront
 investment to create, especially if they are used for high-risk applications,
-which they often are. They are also expensive to operate, requiring both higher
+which they often are. 
+
+They are also expensive to operate, requiring both higher
 transaction fees and an operator with significant technical knowledge (either a
 trained staff member or a commercial service provider which may charge
 additional fees).

--- a/doc/read-the-docs-site/background/credentials.rst
+++ b/doc/read-the-docs-site/background/credentials.rst
@@ -83,14 +83,14 @@ Though many scripting languages target Cardano, there are only two types of scri
 Description of a Plutus script example 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-As an example, a Plutus script can be used to control how a UTxO is spent. 
+As an example, a Plutus script can be used to control how a UTXO is spent. 
 
-The UTxO is held by an address containing the script's payment credential, which is a cryptographic hash of the script's serialized representation. 
-It is also held alongside a piece of data (the *datum*) which can be used to represent the "state" of the script. 
+The UTXO is held by an address containing the script's payment credential, which is a cryptographic hash of the script's serialized representation. 
+It is also held alongside a piece of data (the *datum*) which can be used to represent the 'state' of the script. 
 
-To spend the UTxO, the spending transaction must include the actual script bytes, either directly or via a reference to a script stored elsewhere on chain. 
+To spend the UTXO, the spending transaction must include the actual script bytes, either directly or via a reference to a script stored elsewhere on chain. 
 The transaction can also provide an argument to the script, called a *redeemer*. 
-The script is then executed with the datum held in the UTxO, the redeemer provided in the spending transaction, and a summary of the spending transaction, called the *script context*. 
+The script is then executed with the datum held in the UTXO, the redeemer provided in the spending transaction, and a summary of the spending transaction called the *script context*. 
 
 If it executes without raising an exception, the UTxO is authorized for being spent.
 

--- a/doc/read-the-docs-site/background/credentials.rst
+++ b/doc/read-the-docs-site/background/credentials.rst
@@ -76,9 +76,9 @@ Native scripts and Plutus scripts
 
 Though many scripting languages target Cardano, there are only two types of script credentials: native scripts and Plutus scripts. 
 
-* **Native scripts** --- With native scripts, you can set up simple rules like requiring signatures, setting deadlines, and combining conditions using 'all of' or 'any of' options. 
+* **Native scripts**. With native scripts, you can set up simple rules like requiring signatures, setting deadlines, and combining conditions using 'all of' or 'any of' options. 
 
-* **Plutus scripts** --- Plutus scripts are programs compiled to Untyped Plutus Core, a low-level variant of lambda calculus, that serves as a compilation target for other higher-level scripting languages such as PlutusTx or Aiken.
+* **Plutus scripts**. Plutus scripts are programs compiled to Untyped Plutus Core, a low-level variant of lambda calculus, that serves as a compilation target for other higher-level scripting languages such as PlutusTx or Aiken.
 
 Description of a Plutus script example 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/read-the-docs-site/background/credentials.rst
+++ b/doc/read-the-docs-site/background/credentials.rst
@@ -47,18 +47,11 @@ Disadvantages of public key credentials
 
 However, they also have drawbacks:
 
-* They are single points of failure. If the private key is lost or stolen, the
-  legitimate owner of the credential will be unable to authorize transactions or
-  stop thieves from impersonating them.
-* They are not sufficient for circumstances requiring authorization from multiple
-  individuals.
-* They are opaque on their own --- they do not contain identifiable information.
-  Depending on the application, this can also be an advantage, but not when
-  transparency is important.
-* They may be difficult to change if a credential is compromised. For example,
-  all UTxOs owned by a payment key would need to be sent to the new one,
-  costing the owner ADA in fees. Other types of credentials, particularly
-  constitutional committee cold credentials, are far more difficult to change.
+* Single points of failure. If the private key is lost or stolen, the
+  legitimate owner cannot authorize transactions or prevent theft. 
+* Insufficient for scenarios requiring authorization from multiple individuals.
+* Opaque on their own, lacking identifiable information. This can be an advantage for privacy but a disadvantage when transparency is needed.
+* Difficult to change if compromised. All UTXOs owned by the compromised key must be sent to a new one, incurring ada fees. Other credentials, like constitutional committee cold credentials, are even harder to change. 
 
 All of these drawbacks make public key credentials generally inappropriate for organizations that 
 distribute and delegate authority to staff or other types of trustees.
@@ -99,27 +92,19 @@ Benefits of script credentials
 
 Script credentials offer many benefits over public key credentials:
 
-* They can encode arbitrarily sophisticated security requirements, such as
-  requiring multiple signatures, limiting the amount of an asset that is
-  withdrawn, enforcing time limits, and much more.
-* Via the datum, they can be associated with supplemental information, which
-  can be used for identity verification.
-* They can have failsafe options built into them to allow recovery of the credential
-  if auxillary data, such as private keys, are compromised.
+* They can encode sophisticated security requirements, such as requiring multiple signatures, limiting asset withdrawal amounts, and enforcing time limits.
+* They can be associated with supplemental information via the datum, which can be used for identity verification.
+* They can include failsafe options to allow credential recovery if auxiliary data, such as private keys, are compromised.
 
 Disadvangates of script credentials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 However, they also have several disadvantages:
 
-* They are complicated and expensive to create and use compared with public
-  key credentials.
-* If they are not carefully written and tested, there can be unintended edge
-  cases or bugs that compromise their security.
-* Between the script bytes, the datum and the redeemer, they consume a lot of
-  space in transactions, and are expensive to validate compared with public
-  keys and signatures. This makes them more expensive, as these factors
-  increase transaction fees.
+* They are complicated and expensive to create and use compared with public key credentials.
+* If not carefully written and tested, they can have unintended edge cases or bugs that compromise security.
+* They consume more space in transactions and are more expensive to validate due to the script bytes, datum, and redeemer. This increases transaction fees.
+* They require significant upfront investment, especially for high-risk applications, and are costly to operate, necessitating higher transaction fees and technical expertise, either from trained staff or commercial service providers who may charge additional fees.
 
 Ultimately, script credentials can solve many of the shortcomings of public key
 credentials, but they do so at a cost. They can require significant upfront

--- a/doc/read-the-docs-site/background/credentials.rst
+++ b/doc/read-the-docs-site/background/credentials.rst
@@ -6,7 +6,7 @@ Public key credentials versus script credentials
 On Cardano, anyone can verify the legitimacy of a transaction on the blockchain by using a credential. 
 Credentials are used for many purposes in the Conway era, including:
 
-* Consuming UTxOs
+* Consuming UTXOs
 * Withdrawing staking rewards
 * Publishing governance certificates
 * Voting

--- a/doc/read-the-docs-site/background/credentials.rst
+++ b/doc/read-the-docs-site/background/credentials.rst
@@ -35,12 +35,12 @@ Anyone can use the public key to verify the signature. During verification, the 
 Advantages of public key credentials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are a number of advantages to public key credentials:
+Public key credentials offer several advantages:
 
-* They are easy to create. 
-* They provide quite good security without much room for exploitation, provided that a secure source of randomness was used to generate the key pair, and that the private key is managed securely. 
-* They are cheap to verify and small in size, all of which lowers transaction fees significantly compared with script credentials.
-* They are based on a mature and standard cryptographic algorithm (Ed25519).
+* Easy to create
+* High security if generated with a secure source of randomness and managed properly
+* Cheap to verify and small in size, reducing transaction fees compared to script credentials
+* Based on the mature and standard Ed25519 cryptographic algorithm.
 
 Disadvantages of public key credentials
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/read-the-docs-site/background/index.rst
+++ b/doc/read-the-docs-site/background/index.rst
@@ -1,6 +1,9 @@
 Foundational credential concepts
 ================================
 
+Cardano credential management system
+------------------------------------
+
 While public key credentials are easy to create and cost-effective, script credentials offer more sophisticated security features but are more complex and expensive to operate.
 
 The Cardano Credential Manager system uses two types of credentials for committee members: the cold credential, which is a primary identifier used sparingly for critical authorizations, and the hot credential, which is used frequently for routine committee operations and voting. 

--- a/doc/read-the-docs-site/background/index.rst
+++ b/doc/read-the-docs-site/background/index.rst
@@ -4,9 +4,9 @@ Foundational credential concepts
 Cardano credential management system
 ------------------------------------
 
-While public key credentials are easy to create and cost-effective, script credentials offer more sophisticated security features but are more complex and expensive to operate.
-
 The Cardano Credential Manager system uses two types of credentials for committee members: the cold credential, which is a primary identifier used sparingly for critical authorizations, and the hot credential, which is used frequently for routine committee operations and voting. 
+
+While public key credentials are easy to create and cost-effective, script credentials offer more sophisticated security features but are more complex and expensive to operate.
 
 See the following pages for details. 
 
@@ -14,5 +14,5 @@ See the following pages for details.
    :maxdepth: 1
    :titlesonly:
 
-   credentials
    cc-credentials
+   credentials

--- a/doc/read-the-docs-site/background/index.rst
+++ b/doc/read-the-docs-site/background/index.rst
@@ -1,5 +1,11 @@
-Background Information
-======================
+Foundational credential concepts
+================================
+
+While public key credentials are easy to create and cost-effective, script credentials offer more sophisticated security features but are more complex and expensive to operate.
+
+The Cardano Credential Manager system uses two types of credentials for committee members: the cold credential, which is a primary identifier used sparingly for critical authorizations, and the hot credential, which is used frequently for routine committee operations and voting. 
+
+See the following pages for details. 
 
 .. toctree::
    :maxdepth: 1

--- a/doc/read-the-docs-site/index.rst
+++ b/doc/read-the-docs-site/index.rst
@@ -4,18 +4,50 @@ Constitutional Committee Credential Management System user guide
 Introduction
 ------------
 
-The Constitutional Committee Credential Management System is a suite of Plutus
-scripts and tools for managing Cardano constitutional committee credentials
-with an X.509 certificate chain. It provides the following features:
+The Constitutional Committee credential management system is a framework designed to manage Cardano constitutional committee credentials within the Cardano blockchain ecosystem. It is a suite of Plutus scripts and tools for managing credentials with an X.509 certificate chain, ensuring secure access and operations within the Cardano blockchain for key management and security best practices. 
+
+Purpose and goals
+~~~~~~~~~~~~~~~~~
+
+- Implements constitutional committee credentials with an X.509 certificate tree.
+- Distributes responsibility among different user groups.
+- Allows updating of user groups without changing committee credentials.
+- Ties individual credentials to a publicly verifiable identity.
+
+Functionality
+~~~~~~~~~~~~~
+
+- Manages four script credentials: cold committee, hot committee, cold NFT payment, and hot NFT payment.
+- Uses NFTs to implement system logic through indirection.
+
+Components
+~~~~~~~~~~
+
+- Roles include user roles (membership, delegation, voting) and operational roles (head of security, orchestrator).
+- Scripts with parameters, rules, datum, and redeemers for committee credentials and NFT locking scripts.
+- Processes for auditing, obtaining certificates, and verifying signatories and certificate authority hash.
+
+Operational process
+~~~~~~~~~~~~~~~~~~~
+
+- Orchestrator CLI setup steps: install Nix, clone repository, enter Nix shell.
+- Steps for assembling and submitting transactions, and verifying on-chain changes.
+
+Yawn
+....
+
+It provides the following features:
 
 * Separation of capabilities between user roles
 * Multi-signature authorization of on-chain governance transactions
 * Key rotation without modifying registered committee credentials
 * Publicly verifiable authorization of on-chain activity via certificates
 
-This documentation site includes an overview of the system, a user manual for
-each of the end-user roles, and a reference manual that documents every option
-for every tool.
+
+
+---
+
+This documentation site includes an overview of the system, a user manual for each of the end-user roles, and a reference manual that documents every option for every tool.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/read-the-docs-site/system-overview/auditing.rst
+++ b/doc/read-the-docs-site/system-overview/auditing.rst
@@ -1,36 +1,51 @@
 .. _auditing:
 
-Auditing Transactions
+Auditing transactions
 =====================
 
-This system makes it possible to audit transactions authorized by the
-organization. Anyone with access to an accurate snapshot of the certificate
-hierarchy at the time the transaction was published will be able to verify that
-authorization was given by duly appointed representatives of the organization.
+The credential manager system supports the ability to audit the organization's approved transactions. 
+By having an accurate record of the organization's certificate structure at the time the transaction was made, you can verify that the transaction was authorized by the proper representatives from the organization.
 
-Obtaining the Certificate Hierarchy
------------------------------------
+.. tip::
 
-The first step to verification is to obtain the certificate files from the
-organization. It is up to them how they wish to publish / distribute these.
+   **Summary**
 
+   - **Step 1** --- Get the certificate files from the organization.
+   - **Step 2** --- Extract public keys, identify certificates, hash the PEM file, and match the hashes to verify the signatories.
+   - **Step 3** --- Hash the root certificate PEM file and match it to the `certificateAuthority` field to verify the integrity.
 
-Verifying the Transaction Signatories
+To verify the transaction signatories
 -------------------------------------
 
-The next step is to extract the public keys from the transaction witness set
-and find the certificates which identify them in the certificate hierarchy.
-Note there will be at least one public key hash not in the certificate
-hierarchy, belonging to the orchestrator. This can be ignored. Once the
-corresponding certificate is found, the PEM file can be hashed with the
-``sha-256`` algorithm to obtain a hash digest. If this hash digest matches the
-certificate hash found alongside the public key hash in the datum, the
-signatory was properly authorized to act on behalf of the organization.
+Step 1. Obtain the certificate hierarchy
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Verifying the CA Hash
----------------------
+First, you need to obtain the certificate files from the organization. 
+Each organization decides how they want to publish and distribute these certificates.
 
-Following the chain of certificates to the root self-signed certificate, hash
-the certificate PEM file with ``sha-256``. If it matches the hash in the
-`certificateAuthority` field of the cold lock datum that was in effect when the
-transaction occurred, the integrity of the entire hierarchy can be verified.
+Step 2. Verify the transaction signatories
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Verifying the transaction signatories focuses on validating that the right individuals authorized the transaction.
+
+- **Extract public keys** --- From the transaction witness set, extract the public keys.
+
+- **Identify certificates** --- Find the certificates that correspond to these public keys in the certificate hierarchy. 
+
+   * Note: One public key hash will not be found in the certificate hierarchy because it belongs to the orchestrator. You can ignore this key.
+
+- **Hash the PEM file** --- Use the ``sha-256`` algorithm to hash the PEM (privacy-enhanced mail) file to get a hash digest.
+
+- **Match the hash digest** --- Check if the hash digest matches the certificate hash found alongside the public key hash in the datum. 
+
+If the hashes match, it confirms that the signatory was authorized to act on behalf of the organization.
+
+Step 3. Verify the CA hash
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Verifying the certificate authority hash focuses on validating that the structure that upholds these certificates is genuine and has not been altered.
+
+- **Hash the certificate PEM file** --- Follow the chain of certificates up to the root self-signed certificate. Hash this certificate PEM file using the ``sha-256`` algorithm.
+- **Match the hash** --- Compare this hash to the one in the `certificateAuthority` field of the cold lock datum that was in effect when the transaction occurred. 
+
+If the hashes match, this verifies the integrity of the entire certificate hierarchy.

--- a/doc/read-the-docs-site/system-overview/cold-committee.rst
+++ b/doc/read-the-docs-site/system-overview/cold-committee.rst
@@ -1,39 +1,31 @@
 .. _cold_credential_script:
 
-Cold Committee Credential Script
+Cold committee credential script
 ================================
 
-Parameters
+NFT minting policy ID parameter 
 ----------
 
-A script parameter is a value which gets inlined into the code of the script
-directly when it is compiled / initialized.
-
-The cold committee credential script is parameterized by the minting policy ID
-of an NFT.
+The cold committee credential script requires a specific NFT minting policy ID to function.
+This minting policy ID gets inlined as a parameter into the code of the script directly when it is compiled and initialized. 
 
 Rules
 -----
 
-The script enforces two rules:
+The cold committee credential script enforces two rules:
 
-* The purpose of the script execution must be `Certifying`
-* The transaction must consume a UTxO which contains a token with the given NFT
-  minting policy ID.
+1. The purpose of the script execution must be `Certifying`.
+2. The transaction must consume a UTXO which contains a token with the given NFT minting policy ID.
 
 .. warning::
-  Note that it does not check:
+  Note that the cold committee credential script does *not* check:
 
-  * That the certificate being authorized is a valid certificate for a cold
-    committee credential to be authorized. This check is unnecessary, as the ledger
-    rules would not ask a cold committee credential to authorize any other type
-    of certificate.
-  * That the NFT is actually an NFT, as it doesn't have access to sufficient
-    information to determine this. For that matter, it doesn't check that only
-    one token is spent - in fact the minting policy ID could be the ADA minting
-    policy ID (though the tools we provide to build the credential would not
-    allow this, the script its self doesn't forbid it). It is the responsibility
-    of the credential creator to choose an appropriate NFT.
+  * That the certificate being authorized is a valid certificate for a cold committee credential to be authorized. 
+    This check is unnecessary, as the ledger rules would not ask a cold committee credential to authorize any other type of certificate.
+  * That the NFT is actually an NFT, as it doesn't have access to sufficient information to determine this. 
+    For that matter, it doesn't check that only one token is spent --- in fact, the minting policy ID could be the ada minting policy ID. 
+    Although the tools we provide to build the credential would not allow this, the script itself doesn't forbid it. 
+    It is the responsibility of the credential creator to choose an appropriate NFT.
 
 Datum
 -----
@@ -43,5 +35,5 @@ Committee script credentials do not have a datum.
 Redeemer
 --------
 
-Untyped, not used. The most efficient is to use the integer ``0`` for the
-redeemer.
+Untyped, not used. 
+The most efficient is to use the integer ``0`` for the redeemer.

--- a/doc/read-the-docs-site/system-overview/cold-committee.rst
+++ b/doc/read-the-docs-site/system-overview/cold-committee.rst
@@ -4,7 +4,7 @@ Cold committee credential script
 ================================
 
 NFT minting policy ID parameter 
-----------
+-------------------------------
 
 The cold committee credential script requires a specific NFT minting policy ID to function.
 This minting policy ID gets inlined as a parameter into the code of the script directly when it is compiled and initialized. 

--- a/doc/read-the-docs-site/system-overview/cold-nft.rst
+++ b/doc/read-the-docs-site/system-overview/cold-nft.rst
@@ -1,88 +1,101 @@
 .. _cold_nft_locking_script:
 
-Cold NFT Locking Script
+Cold NFT locking script
 =======================
 
-Parameters
+Cold committee credential parameters
 ----------
 
-The cold NFT locking script is parameterized by the cold committee credential.
+The cold NFT locking script requires a specific cold committee credential to function.
+This cold committee credential gets inlined as a parameter in the code of the cold NFT locking script directly when it is compiled and initialized. 
 
 Rules
 -----
 
 The script enforces the following rules unconditionally:
 
-* The purpose of the script execution must be `Spending`
-* The UTxO being spent must be in the transaction's inputs (this will always be
-  the case when the script is invoked by a properly implemented ledger layer).
+* The purpose of the script execution must be `Spending`.
+* The UTXO being spent must be in the transaction's inputs (this will always be the case when the script is invoked by a properly implemented ledger layer).
 
-The script enforces additional rules depending on the redeemer:
+The script enforces the following additional rules depending on the redeemer:
+
+Rules for ``AuthorizeHot`` actions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the redeemer is an ``AuthorizeHot`` action:
 
-* The transaction produces an output that is identical to the input being
-  authorized.
-* The transaction does not send any other outputs to an address with the the
-  script's own payment credential.
-* The transaction has been signed by a majority of users from the
-  **delegation group** defined in the datum.
-* The transaction contains a hot committee credential authorization certificate
+* The transaction produces an output that is identical to the input being authorized.
+* The transaction does not send any other outputs to an address with the script's own payment credential.
+* The transaction has been signed by a majority of users from the **delegation group** defined in the datum.
+* The transaction contains a hot committee credential authorization certificate. 
+
   * The cold credential contained in the certificate is the same credential provided to the script as a parameter.
-  * the hot credential contained in the certificate is the same credential provided in the redeemer.
+  * The hot credential contained in the certificate is the same credential provided in the redeemer.
+
 * The transaction does not contain any other certificates.
+
+Rules for ``ResignDelegation`` actions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the redeemer is a ``ResignDelegation`` action:
 
 * The transaction sends an output that meets the following criteria:
-  * The address matches the address of the input being authorized
+
+  * The address matches the address of the input being authorized.
   * The value of the output is the same as the value of the input being authorized.
-  * The datum is unchanged with the exception that the resignee specified in the redeemer is removed from the **delegation group**.
-  * The reference script in the output is the same if present, otherwise not set.
-* The transaction does not send any other outputs to an address with the the
-  script's own payment credential.
+  * The datum is unchanged except that the resignee specified in the redeemer is removed from the **delegation group**.
+  * The reference script in the output is the same if present, otherwise it is not set.
+
+* The transaction does not send any other outputs to an address with the script's own payment credential.
 * The transaction has been signed by the resignee.
 * The resignee is a member of the **delegation group** defined by the datum.
-* The resignee is not the last member of the **delegation group**, which would
-  leave the group empty.
+* The resignee is not the last member of the **delegation group**, which would leave the group empty.
 * The transaction does not contain any certificates.
+
+Rules for ``ResignCold`` actions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the redeemer is a ``ResignCold`` action:
 
-* The transaction produces an output that is identical to the input being
-  authorized.
-* The transaction does not send any other outputs to an address with the the
-  script's own payment credential.
-* The transaction has been signed by a majority of users from the
-  **membership group** defined in the datum.
+* The transaction produces an output that is identical to the input being authorized.
+* The transaction does not send any other outputs to an address with the script's own payment credential.
+* The transaction has been signed by a majority of users from the **membership group** defined in the datum.
 * The transaction contains a cold committee resignation certificate.
+
   * The cold credential contained in the certificate is the same credential provided to the script as a parameter.
+
 * The transaction does not contain any other certificates.
+
+Rules for ``RotateCold`` actions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the redeemer is a ``RotateCold`` action:
 
 * The transaction sends an output that meets the following criteria:
-  * The address matches the address of the input being authorized
+
+  * The address matches the address of the input being authorized.
   * The value of the output is the same as the value of the input being authorized.
   * The **certificate authority** is the same in the output datum as it is in the input datum.
-  * the **membership group** in the output datum is not empty.
-  * the **delegation group** in the output datum is not empty.
+  * The **membership group** in the output datum is not empty.
+  * The **delegation group** in the output datum is not empty.
   * The output does not contain a reference script.
-* The transaction does not send any other outputs to an address with the the
-  script's own payment credential.
-* The transaction has been signed by a majority of users from the
-  **membership group** defined in the input datum.
+
+* The transaction does not send any other outputs to an address with the script's own payment credential.
+* The transaction has been signed by a majority of users from the **membership group** defined in the input datum.
 * The transaction does not contain any certificates.
+
+Rules for ``UnlockCold`` actions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the redeemer is an ``UnlockCold`` action:
 
-* The transaction has been signed by a majority of users from the
-  **membership group** defined in the input datum.
+* The transaction has been signed by a majority of users from the **membership group** defined in the input datum.
 
 Datum
 -----
 
-Main schema:
+Main schema
+~~~~~~~~~~~
 
 * **Type**: constructor
 * **Valid constructor indexes**:
@@ -91,19 +104,15 @@ Main schema:
           * Field 1:
               * **Type**: :ref:`Identity <identity_schema>`
               * **Haskell Name** ``certificateAuthority``
-              * **Description**: The public key hash and certificate hash of the
-                certificate authority which issued all child X.509 certificates in
-                the datum.
+              * **Description**: The public key hash and certificate hash of the certificate authority which issued all child X.509 certificates in the datum.
           * Field 2:
               * **Type**: List of :ref:`Identities <identity_schema>`
               * **Haskell Name** ``membershipUsers``
-              * **Description**: The public key hashes and certificate hashes
-                of the users in the **membership group**.
+              * **Description**: The public key hashes and certificate hashes of the users in the **membership group**.
           * Field 3:
               * **Type**: List of :ref:`Identities <identity_schema>`
               * **Haskell Name** ``delegationUsers``
-              * **Description**: The public key hashes and certificate hashes
-                of the users in the **delegation group**.
+              * **Description**: The public key hashes and certificate hashes of the users in the **delegation group**.
 
 .. _identity_schema:
 
@@ -127,6 +136,7 @@ Redeemer
 --------
 
 Main schema
+~~~~~~~~~~~
 
 * **Type**: constructor
 * **Valid constructor indexes**:
@@ -139,44 +149,46 @@ Main schema
     1. * **Haskell Name**: ``ResignCold``
        * **Description**: Require the transaction to resign from the committee.
     2. * **Haskell Name**: ``ResignDelegation``
-       * **Description**: Require the transaction to remove a user from the
-         **delegation group**.
+       * **Description**: Require the transaction to remove a user from the **delegation group**.
        * **Fields**:
           * Field 1:
               * **Type**: :ref:`Identity <identity_schema>`
               * **Description**: The resignee.
     3. * **Haskell Name**: ``RotateCold``
-       * **Description**: Allow the transaction to change the members of the
-         **membership group** and **delegation group**.
+       * **Description**: Allow the transaction to change the members of the **membership group** and **delegation group**.
     4. * **Haskell Name**: ``UnlockCold``
        * **Description**: Allow the transaction to spend the NFT freely.
 
 .. _unlock_cold:
 
-Note on ``UnlockCold``
-----------------------
+Q&A about ``UnlockCold``
+------------------------
 
-It is reasonable to ask why, if the membership group can spend the NFT without
-restriction anyway, is it necessary to include more specific actions such as
-``RotateCold`` or ``ResignCold``? The answer is that the unlock action
-is very dangerous, as it does not check anything beyond that the transaction is
-signed. If a transaction does something unintended with the NFT while unlocking
-it, it could render the cold credential unusable or worse, give that control to
-someone else. So the more restrictive actions are available to cover known use
-cases and provide additional safety guarantees not provided by the unlock
-action.
+Question
+~~~~~~~~
 
-It would also be reasonable to ask why the unlock action is available if it is
-so dangerous? The answer is that not including it is also dangerous. Consider
-what would happen if a security flaw was found in the cold NFT locking script.
-If the unlock action wasn't available, there would be no way to send the NFT to
-a patched version of the script, because all other actions require the NFT to
-be sent back to the address from which it originated. The only way to prevent
-the security flaw from being exploited would be to resign from the committee,
-which is irrecoverable without an election, a process beyond the ability of the
-committee member to control.
+If the membership group can spend the NFT without restriction, why is it necessary to include more specific actions such as ``RotateCold`` or ``ResignCold``? 
+
+Answer
+~~~~~~
+
+The unlock action is very dangerous, as it does not check anything beyond that the transaction is signed. 
+If a transaction does something unintended with the NFT while unlocking it, it could render the cold credential unusable or worse --- give that control to someone else. 
+The more restrictive actions are available to cover known use cases and to provide additional safety guarantees not provided by the unlock action.
+
+Question
+~~~~~~~~
+
+Why is the unlock action available if it is so dangerous? 
+
+Answer
+~~~~~~
+
+Not including the unlock action is also dangerous. 
+Consider what would happen if a security flaw was found in the cold NFT locking script.
+If the unlock action wasn't available, there would be no way to send the NFT to a patched version of the script, because all other actions require the NFT to be sent back to the address from which it originated. 
+The only way to prevent the security flaw from being exploited would be to resign from the committee, which is irrecoverable without an election, a process beyond the ability of the committee member to control.
 
 .. warning::
-   As mentioned before, the **membership group** has full control over the cold
-   NFT, and consequently the cold credential its self. Refer to the warning in
-   :ref:`system_overview` for guidelines to mitigate this risk.
+   As mentioned before, the **membership group** has full control over the cold NFT, and consequently the cold credential itself. 
+   Refer to the warning in :ref:`system_overview` for guidelines on mitigating this risk.

--- a/doc/read-the-docs-site/system-overview/cold-nft.rst
+++ b/doc/read-the-docs-site/system-overview/cold-nft.rst
@@ -4,7 +4,7 @@ Cold NFT locking script
 =======================
 
 Cold committee credential parameters
-----------
+------------------------------------
 
 The cold NFT locking script requires a specific cold committee credential to function.
 This cold committee credential gets inlined as a parameter in the code of the cold NFT locking script directly when it is compiled and initialized. 

--- a/doc/read-the-docs-site/system-overview/hot-committee.rst
+++ b/doc/read-the-docs-site/system-overview/hot-committee.rst
@@ -1,38 +1,30 @@
 .. _hot_credential_script:
 
-Hot Committee Credential Script
+Hot committee credential script
 ================================
 
-Parameters
+NFT minting policy ID parameter 
 ----------
 
-A script parameter is a value which gets inlined into the code of the script
-directly when it is compiled / initialized.
-
-The hot committee credential script is parameterized by the minting policy ID
-of an NFT.
+The hot committee credential script requires a specific NFT minting policy ID to function.
+This minting policy ID gets inlined as a parameter into the code of the script directly when it is compiled and initialized. 
 
 Rules
 -----
 
-The script enforces two rules:
+The hot committee credential script enforces two rules: 
 
-* The purpose of the script execution must be `Voting`
-* The transaction must consume a UTxO which contains a token with the given NFT
-  minting policy ID.
+1. The purpose of the script execution must be `Voting`.
+2. The transaction must consume a UTxO which contains a token with the given NFT minting policy ID.
 
 .. warning::
-  Note that it does not check:
+  Note that the hot committee credential script does *not* check:
 
-  * Details of the vote, including the identity of the voter. This check is
-    unnecessary, as the ledger rules would not ask a hot committee credential
-    to authorize votes by other voters.
-  * That the NFT is actually an NFT, as it doesn't have access to sufficient
-    information to determine this. For that matter, it doesn't check that only
-    one token is spent - in fact the minting policy ID could be the ADA minting
-    policy ID (though the tools we provide to build the credential would not
-    allow this, the script its self doesn't forbid it). It is the responsibility
-    of the credential creator to choose an appropriate NFT.
+  * Details of the vote, including the identity of the voter. 
+    This check is unnecessary, as the ledger rules would not ask a hot committee credential to authorize votes by other voters.
+  * That the NFT is actually an NFT, as it doesn't have access to sufficient information to determine this. 
+    For that matter, it doesn't check that only one token is spent --- in fact the minting policy ID could be the ada minting policy ID (though the tools we provide to build the credential would not allow this, the script its self doesn't forbid it). 
+    It is the responsibility of the credential creator to choose an appropriate NFT.
 
 Datum
 -----
@@ -42,5 +34,4 @@ Committee script credentials do not have a datum.
 Redeemer
 --------
 
-Untyped, not used. The most efficient is to use the integer ``0`` for the
-redeemer.
+Untyped, not used. The most efficient is to use the integer ``0`` for the redeemer.

--- a/doc/read-the-docs-site/system-overview/hot-committee.rst
+++ b/doc/read-the-docs-site/system-overview/hot-committee.rst
@@ -4,7 +4,7 @@ Hot committee credential script
 ================================
 
 NFT minting policy ID parameter 
-----------
+-------------------------------
 
 The hot committee credential script requires a specific NFT minting policy ID to function.
 This minting policy ID gets inlined as a parameter into the code of the script directly when it is compiled and initialized. 

--- a/doc/read-the-docs-site/system-overview/hot-nft.rst
+++ b/doc/read-the-docs-site/system-overview/hot-nft.rst
@@ -1,79 +1,88 @@
 .. _hot_nft_locking_script:
 
-Hot NFT Locking Script
+Hot NFT locking script
 =======================
 
 Parameters
 ----------
 
-The hot NFT locking script is parameterized by the cold NFT minting policy ID
-and the hot committee credential.
+The hot NFT locking script requires a specific cold NFT minting policy ID and hot committee credential to function; 
+These are inlined as parameters in the code of the hot NFT locking script directly when it is compiled and initialized.
 
 Rules
 -----
 
 The script enforces the following rules unconditionally:
 
-* The purpose of the script execution must be `Spending`
-* The UTxO being spent must be in the transaction's inputs (this will always be
-  the case when the script is invoked by a properly implemented ledger layer).
+* The purpose of the script execution must be `Spending`.
+* The UTXO being spent must be in the transaction's inputs; this will always be the case when a properly implemented ledger layer invokes the script.
 
-The script enforces additional rules depending on the redeemer:
+The script enforces the following additional rules depending on the redeemer:
 
-If the redeemer is a ``Vote`` action:
+Rules for ``Vote`` actions
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-* The transaction produces an output that is identical to the input being
-  authorized.
-* The transaction does not send any other outputs to an address with the the
-  script's own payment credential.
-* The transaction has been signed by a majority of users from the
-  **voting group** defined in the datum.
-* The transaction contains a committee voting procedure:
+If the redeemer is a ``Vote`` action, the transaction:
+
+* Produces an output that is identical to the input being authorized.
+* Does not send any other outputs to an address with the script's own payment credential.
+* Has been signed by a majority of users from the **voting group** defined in the datum.
+* Does not contain votes from other voters.
+* Contains the following committee voting procedure:
+
   * The hot credential performing the vote is the same credential provided to the script as a parameter.
   * The voting procedure casts one or more votes.
-* The transaction does not contain votes from other voters.
+
+Rules for ``ResignVoting`` actions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the redeemer is a ``ResignVoting`` action:
 
 * The transaction sends an output that meets the following criteria:
-  * The address matches the address of the input being authorized
+
+  * The address matches the address of the input being authorized.
   * The value of the output is the same as the value of the input being authorized.
   * The datum is unchanged with the exception that the resignee specified in the redeemer is removed from the **voting group**.
-  * The reference script in the output is the same if present, otherwise not set.
-* The transaction does not send any other outputs to an address with the the
-  script's own payment credential.
+  * The reference script in the output is the same if present, otherwise it is not set.
+
+* The transaction does not send any other outputs to an address with the script's own payment credential.
 * The transaction has been signed by the resignee.
 * The resignee is a member of the **voting group** defined by the datum.
-* The resignee is not the last member of the **voting group**, which would
-  leave the group empty.
+* The resignee is not the last member of the **voting group**, which would leave the group empty.
 * The transaction does not contain any votes.
+
+Rules for ``RotateHot`` actions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the redeemer is a ``RotateHot`` action:
 
 * The transaction sends an output that meets the following criteria:
-  * The address matches the address of the input being authorized
+
+  * The address matches the address of the input being authorized.
   * The value of the output is the same as the value of the input being authorized.
   * the **voting group** in the output datum is not empty.
   * The output does not contain a reference script.
-* The transaction does not send any other outputs to an address with the the
-  script's own payment credential.
-* The transaction includes a reference input that holds the cold NFT
-  * The reference input contains a valid ``ColdLockDatum``.
-* The transaction has been signed by a majority of users from the
-  **delegation group** defined in the reference input's datum.
+
+* The transaction does not send any other outputs to an address with the script's own payment credential.
+* The transaction includes a reference input that holds the cold NFT.
+* The reference input contains a valid ``ColdLockDatum``.
+* The transaction has been signed by a majority of users from the **delegation group** defined in the reference input's datum.
 * The transaction does not contain any votes.
+
+Rules for ``UnlockHot`` actions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If the redeemer is an ``UnlockHot`` action:
 
-* The transaction includes a reference input that holds the cold NFT
-  * The reference input contains a valid ``ColdLockDatum``.
-* The transaction has been signed by a majority of users from the
-  **delegation group** defined in the reference input's datum.
+* The transaction includes a reference input that holds the cold NFT.
+* The reference input contains a valid ``ColdLockDatum``.
+* The transaction has been signed by a majority of users from the **delegation group** defined in the reference input's datum.
 
 Datum
 -----
 
-Main schema:
+Main schema
+~~~~~~~~~~~
 
 * **Type**: constructor
 * **Valid constructor indexes**:
@@ -82,34 +91,31 @@ Main schema:
           * Field 1:
               * **Type**: List of :ref:`Identities <identity_schema>`
               * **Haskell Name** ``votingUsers``
-              * **Description**: The public key hashes and certificate hashes
-                of the users in the **voting group**.
+              * **Description**: The public key hashes and certificate hashes of the users in the **voting group**.
 
 Redeemer
 --------
 
 Main schema
+~~~~~~~~~~~
 
 * **Type**: constructor
 * **Valid constructor indexes**:
     0. * **Haskell Name**: ``Vote``
        * **Description**: Require the transaction to cast a committee vote.
     1. * **Haskell Name**: ``ResignVoting``
-       * **Description**: Require the transaction to remove a user from the
-         **voting group**.
+       * **Description**: Require the transaction to remove a user from the **voting group**.
        * **Fields**:
           * Field 1:
               * **Type**: :ref:`Identity <identity_schema>`
               * **Description**: The resignee.
     2. * **Haskell Name**: ``RotateHot``
-       * **Description**: Allow the transaction to change the members of the
-         **voting group**.
+       * **Description**: Allow the transaction to change the members of the **voting group**.
     3. * **Haskell Name**: ``UnlockHot``
        * **Description**: Allow the transaction to spend the NFT freely.
 
 See :ref:`Note on UnlockCold <unlock_cold>` for comments also applicable to ``UnlockHot``.
 
 .. warning::
-   The **delegation group** has full control over the hot NFT, and consequently
-   the hot credential its self. **delegation group** members should safeguard
-   their keys as if they were keys for the hot credential its self.
+   The **delegation group** has full control over the hot NFT, and consequently the hot credential itself. 
+   **delegation group** members should safeguard their keys as if they were keys for the hot credential itself.

--- a/doc/read-the-docs-site/system-overview/index.rst
+++ b/doc/read-the-docs-site/system-overview/index.rst
@@ -1,16 +1,13 @@
 .. _system_overview:
 
-System Overview
+System overview
 ===============
 
-This system implements constitutional committee credentials that are backed by
-an X.509 certificate tree, composed of multiple sub-credentials. Its goals are:
+This system implements constitutional committee credentials that are backed by an X.509 certificate tree, composed of multiple sub-credentials. Its goals are:
 
 * Distribute responsibility between different groups of users.
-* Allow user groups to be updated (rotated) without changing the committee
-  credentials.
-* Tie individual's credential to publicly verifiable identity via X.509
-  certificate chains for transparency and audit compliance.
+* Allow user groups to be updated (rotated) without changing the committee credentials.
+* Tie individual's credential to publicly verifiable identity via X.509 certificate chains for transparency and audit compliance.
 
 At a high level, it works by coordinating four script credentials:
 
@@ -19,48 +16,31 @@ At a high level, it works by coordinating four script credentials:
 * A :ref:`cold NFT payment script credential <cold_nft_locking_script>`
 * A :ref:`hot NFT payment script credential <hot_nft_locking_script>`
 
-The two committee credential scripts are registered as the actual hot and cold
-committee credentials on-chain. However they do not contain the majority of the
-system's logic for two reasons:
+The two committee credential scripts are registered as the actual hot and cold committee credentials on-chain. 
+However they do not contain the majority of the system's logic for two reasons:
 
-* Committee credentials cannot be associated with a datum, so any information
-  they depend on like lists of users must be hard-coded in the script.
-* If the system needs to be updated, for example to apply security patches, the
-  committee credentials would need to be replaced, which is the situation the
-  system is intended to avoid.
+* Committee credentials cannot be associated with a datum, so any information they depend on like lists of users must be hard-coded in the script.
+* If the system needs to be updated --- for example, to apply security patches --- the committee credentials would need to be replaced, which is the situation the system is intended to avoid.
 
-Instead, they both employ a layer of indirection to delegate the logic to
-payment credentials, which do not suffer from these two problems. To do this,
-they only require that a known NFT is spent by the transaction. The payment
-credential that holds this NFT implements the real logic of the system.
+Instead, they both employ a layer of indirection to delegate the logic to payment credentials, which do not suffer from these two problems. 
+To do this, they require only that a known NFT is spent by the transaction. 
+The payment credential that holds this NFT implements the real logic of the system.
 
 .. warning::
-   This system replaces control of a private key with control of an NFT. The
-   loss of control of either NFT is equivalent to the loss of control of either
-   committee credential. To mitigate the risks involved, it is imperative to
-   follow these guidelines, neither of which are enforced by the system:
+   This system replaces control of a private key with control of an NFT. 
+   The loss of control of either NFT is equivalent to the loss of control of either committee credential. 
+   To mitigate the risks involved, it is imperative to follow these guidelines, neither of which are enforced by the system:
 
-   * The cold and hot credentials must be associated with different minting
-     policy IDs.
-   * The NFTs must be true NFTs, which is to say their minting policy must
-     guarantee they can never be minted again (for example by requiring that a
-     specific UTxO is spent to mint them).
-   * There must only ever be one token minted with each policy ID. **The scripts
-     do not check token names, they only check minting policy IDs**. So an NFT
-     is not safe to use if other tokens have been minted with the same policy,
-     even if they have different token names.
-   * The signing keys used by the user groups to spend these NFTs must be
-     managed according to established
+   * The cold and hot credentials must be associated with different minting policy IDs.
+   * The NFTs must be true NFTs, which is to say their minting policy must guarantee they can never be minted again (for example by requiring that a specific UTxO is spent to mint them).
+   * There must only ever be one token minted with each policy ID. 
+     **The scripts do not check token names, they only check minting policy IDs**. 
+     So an NFT is not safe to use if other tokens have been minted with the same policy, even if they have different token names.
+   * The signing keys used by the user groups to spend these NFTs must be managed according to established
      `security best practices <https://developers.cardano.org/docs/get-started/secure-workflow>`_.
-   * The above is especially true for users in the **membership** group, who
-     have the power to arbitrarily spend the Cold NFT. It is recommended that
-     the members of this group are technically skilled, trustworthy individuals
-     who have the knowledge, skills, and equipment required to manage keys
-     securely.
-   * In addition to secure key management, it is equally important to use
-     `Cryptographically secure sources of entropy <https://en.wikipedia.org/wiki/Cryptographically_secure_pseudorandom_number_generator>`_
-     to generate these keys, such as `/dev/urandom` on Unix-based systems and
-     it is important to properly instruct users how to do this.
+   * The above is especially true for users in the **membership** group, who have the power to arbitrarily spend the Cold NFT. 
+     It is recommended that the members of this group are technically skilled, trustworthy individuals who have the knowledge, skills, and equipment required to manage keys securely.
+   * In addition to secure key management, it is equally important to use `Cryptographically secure sources of entropy <https://en.wikipedia.org/wiki/Cryptographically_secure_pseudorandom_number_generator>`_ to generate these keys, such as `/dev/urandom` on Unix-based systems and it is important to properly instruct users how to do this.
 
 .. toctree::
    :maxdepth: 1

--- a/doc/read-the-docs-site/system-overview/roles.rst
+++ b/doc/read-the-docs-site/system-overview/roles.rst
@@ -65,6 +65,8 @@ Operational roles
 Operational roles are not explicitly included in the organization's certificate hierarchy. 
 They are implicit roles that describe tasks which must be managed by the organization somehow, but the system does not explicitly keep track of them the way it does with the user roles.
 
+.. _head_of_security:
+
 Head of security
 ----------------
 

--- a/doc/read-the-docs-site/system-overview/roles.rst
+++ b/doc/read-the-docs-site/system-overview/roles.rst
@@ -20,7 +20,7 @@ There are three types of user roles in the system, each with distinct responsibi
 * voting role.
 
 Membership role controls the cold credential 
----------------
+--------------------------------------------
 
 The membership role collectively controls the cold credential. 
 They are able to perform the following actions:
@@ -35,7 +35,7 @@ As such, it is imperative that this responsibility be entrusted to individuals w
 If they lack these qualifications, they SHOULD entrust management of their keys to a qualified key custodian.
 
 Delegation role controls the hot credential 
----------------
+-------------------------------------------
 
 The delegation role collectively controls the hot credential. 
 They are able to perform the following actions:
@@ -50,7 +50,7 @@ They are also indirectly capable of authorizing any action the voting roles can 
 The delegation role also has a significant responsibility to safeguard their credentials; however, they are supervised by the membership role, so there is more of a safety net in place for this role compared with the membership role.
 
 Voting role authorizes votes
------------
+----------------------------
 
 The voting role authorizes votes. 
 This is the main working group in the system --- they are the ones with the responsibility to deliberate and decide how to vote on governance actions, write and publish rationale documents, and coordinate with the orchestrator to publish votes. 

--- a/doc/read-the-docs-site/system-overview/roles.rst
+++ b/doc/read-the-docs-site/system-overview/roles.rst
@@ -3,100 +3,86 @@
 Roles
 *****
 
-The system considers two types of role: user roles, which are part of the X.509
-certificate hierarchy, and operational roles which are not.
+The system recognizes and distinguishes between two types of roles: 
 
-User Roles
+1. user roles, which are part of the X.509 certificate hierarchy 
+2. operational roles, which are not.
+
+User roles
 ==========
 
-User roles are roles for which membership is defined by inclusion in the X.509
-certificate hierarchy. Specifically, they are defined by the leaf certificates.
-There are three type of user role in the system, each with distinct
-responsibilities: membership, delegation, and voting.
+User roles are defined by being included in the X.509 certificate hierarchy. 
+Specifically, they are defined by the leaf certificates.
+There are three types of user roles in the system, each with distinct responsibilities: 
 
-Membership Role
+* membership role
+* delegation role 
+* voting role.
+
+Membership role controls the cold credential 
 ---------------
 
-The membership role collectively controls the cold credential. They are able to
-perform the following actions:
+The membership role collectively controls the cold credential. 
+They are able to perform the following actions:
 
 * Resign from the committee
-* Rotate the membership and delegation keys in the cold NFT datum.
+* Rotate the membership and delegation keys in the cold NFT datum
 * Unlock the cold NFT and spend it arbitrarily.
 
-They are also indirectly capable of authorizing any action the delegation and
-voting roles can authorize, because they can decide who is in the delegation
-role, which in turn has the power to decide who is in the voting role.
+They are also indirectly capable of authorizing any action the delegation and voting roles can authorize, because they can decide who is in the delegation role, which in turn has the power to decide who is in the voting role.
 
-As such, it is imperative that this responsibility be entrusted to individuals
-who are trusted by the organization, and who have the knowledge, skills, and
-equipment necessary to securely safeguard their keys. If they lack these
-qualifications, they SHOULD entrust management of their keys to a qualified
-key custodian.
+As such, it is imperative that this responsibility be entrusted to individuals who are trusted by the organization, and who have the knowledge, skills, and equipment necessary to securely safeguard their keys. 
+If they lack these qualifications, they SHOULD entrust management of their keys to a qualified key custodian.
 
-Delegation Role
+Delegation role controls the hot credential 
 ---------------
 
-The delegation role collectively controls the hot credential. They are able to
-perform the following actions:
+The delegation role collectively controls the hot credential. 
+They are able to perform the following actions:
 
-* Authorize new hot credentials on behalf of the cold credential.
-* Resign from the delegation role.
-* Rotate the voting keys in the hot NFT datum.
+* Authorize new hot credentials on behalf of the cold credential
+* Resign from the delegation role
+* Rotate the voting keys in the hot NFT datum
 * Unlock the hot NFT and spend it arbitrarily.
 
-They are also indirectly capable of authorizing any action the voting roles can
-authorize, because they can decide who is in the voting role.
+They are also indirectly capable of authorizing any action the voting roles can authorize, because they can decide who is in the voting role.
 
-The delegation role also has a significant responsibility to safeguard their
-credentials, however they are supervised by the membership role, so there is
-more of a safety net in place for this role compared with the membership role.
+The delegation role also has a significant responsibility to safeguard their credentials; however, they are supervised by the membership role, so there is more of a safety net in place for this role compared with the membership role.
 
-Voting Role
+Voting role authorizes votes
 -----------
 
-The voting role authorizes votes. This is the main working group in the system
-- they are the ones with the responsibility to deliberate and decide how to
-vote on governance actions, write and publish rationale documents, and
-coordinate with the orchestrator to publish votes. They are able to perform the
-following actions:
+The voting role authorizes votes. 
+This is the main working group in the system --- they are the ones with the responsibility to deliberate and decide how to vote on governance actions, write and publish rationale documents, and coordinate with the orchestrator to publish votes. 
+They are able to perform the following actions:
 
-* Vote on governance actions.
+* Vote on governance actions
 * Resign from the voting role.
 
-Operational Roles
+Operational roles
 =================
 
-Operational roles are not explicitly included in the organization's certificate
-hierarchy. They are implicit roles that describe tasks which must be managed by
-the organization somehow, but the system does not explicitly keep track of them
-the way it does with the user roles.
+Operational roles are not explicitly included in the organization's certificate hierarchy. 
+They are implicit roles that describe tasks which must be managed by the organization somehow, but the system does not explicitly keep track of them the way it does with the user roles.
 
-.. _head_of_security:
-
-Head of Security
+Head of security
 ----------------
 
-The head of security is responsible for managing the X.509 certificate
-hierarchy, which includes signing certificate signing requests from user roles,
-maintaining the organization's store of certificates, and managing the higher
-levels of certificates in the organization's hierarchy. They also maintain the
-certificate revocation list. This system does not provide tooling for the head
-of security - tooling for managing X.509 certificate hierarchies already exists,
-for example ``openssl``.
+The head of security is responsible for managing the X.509 certificate hierarchy, which includes signing certificate signing requests from user roles, maintaining the organization's store of certificates, and managing the higher levels of certificates in the organization's hierarchy. 
+They also maintain the certificate revocation list. 
+This system does not provide tooling for the head of security --- tooling for managing X.509 certificate hierarchies already exists, for example ``openssl``.
 
 Orchestrator
 ------------
 
-The orchestrator is responsible for operating the system. Their
-responsibilities include:
+The orchestrator is responsible for operating the system. 
+Their responsibilities include:
 
-* Minting or procuring the NFTs.
-* Initializing and maintaining the scripts.
-* Building transactions as directed by the user groups.
-* Distributing transactions to the user groups for signing.
-* Covering transaction fees.
+* Minting or procuring the NFTs
+* Initializing and maintaining the scripts
+* Building transactions as directed by the user groups
+* Distributing transactions to the user groups for signing
+* Covering transaction fees
 * Submitting transactions.
 
-This system includes a CLI tool to help orchestrators prepare the various
-transactions they need to create to operate the system.
+Orchestrators use the credential manager's CLI tool to prepare and create the various transactions needed to operate the system. 


### PR DESCRIPTION
I'm suggesting a bunch of edits to the background info section of the credential manager docs including renaming the section and the pages. My aim was to simplify the message as much as possible, reduce info that can be confusing and not strictly required, and add a little bit of practical context. Let's discuss as needed. 