### PR TITLE
Implement audit findings

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -16,8 +16,8 @@ repository cardano-haskell-packages
 -- See https://github.com/input-output-hk/haskell.nix/issues/1869#issuecomment-1449272480
 index-state: 2024-07-09T00:00:00Z
 index-state:
-  , hackage.haskell.org 2024-07-09T00:00:00Z
-  , cardano-haskell-packages 2024-07-09T00:00:00Z
+  , hackage.haskell.org 2024-08-15T00:00:00Z
+  , cardano-haskell-packages 2024-08-15T00:00:00Z
 
 packages:
   credential-manager

--- a/credential-manager/credential-manager.cabal
+++ b/credential-manager/credential-manager.cabal
@@ -89,7 +89,7 @@ library
     , asn1-types
     , base >=4.18 && <5
     , bytestring ^>=0.11
-    , cardano-api ^>=9.0
+    , cardano-api ^>=9.1
     , crypton ^>=0.34
     , crypton-x509 ^>=1.7
     , memory ^>=0.18
@@ -135,7 +135,7 @@ library orchestrator
   build-depends:
     , base >=4.18 && <5
     , bytestring
-    , cardano-api ^>=9.0
+    , cardano-api ^>=9.1
     , cardano-ledger-conway
     , containers
     , credential-manager:{credential-manager, plutus-scripts}

--- a/credential-manager/src/CredentialManager/Scripts/ColdCommittee.hs
+++ b/credential-manager/src/CredentialManager/Scripts/ColdCommittee.hs
@@ -29,13 +29,13 @@ import PlutusTx.Prelude hiding (trace, traceIfFalse)
 -- in any spending input of the transaction.
 {-# INLINEABLE coldCommitteeScript #-}
 coldCommitteeScript :: AssetClass -> ScriptContext -> Bool
-coldCommitteeScript nft ScriptContext{..} = case scriptContextScriptInfo of
+coldCommitteeScript nft ScriptContext{scriptContextScriptInfo, scriptContextTxInfo} = case scriptContextScriptInfo of
   CertifyingScript _ _ ->
     traceIfFalse "Cold NFT not found in any input" $ any inputSpendsToken txInputs
   _ -> trace "Invalid script purpose" False
   where
     -- Checks if an input spends the correct token
-    inputSpendsToken TxInInfo{txInInfoResolved = TxOut{..}} =
+    inputSpendsToken TxInInfo{txInInfoResolved = TxOut{txOutValue}} =
       assetClassValueOf txOutValue nft == 1
     -- The list of transaction inputs being consumed in this transaction.
     txInputs = txInfoInputs scriptContextTxInfo

--- a/credential-manager/src/CredentialManager/Scripts/ColdNFT.hs
+++ b/credential-manager/src/CredentialManager/Scripts/ColdNFT.hs
@@ -37,42 +37,42 @@ coldNFTScript
   -> ScriptContext
   -> Bool
 coldNFTScript coldNFT coldCred =
-  checkSpendingTx coldNFT \txInfo@TxInfo{txInfoTxCerts, txInfoOutputs, txInfoSignatories} inAddress inValue inRefScript datumIn -> \case
+  checkSpendingTx coldNFT \txInfo@TxInfo{txInfoTxCerts, txInfoOutputs, txInfoSignatories} inAddress inValue datumIn -> \case
     AuthorizeHot hotCred ->
-      checkSelfPreservation inAddress inValue inRefScript txInfoOutputs datumIn
+      checkSelfPreservation inAddress inValue txInfoOutputs datumIn
         && checkMultiSig (delegationUsers datumIn) txInfoSignatories
         && checkCertificate txInfoTxCerts (TxCertAuthHotCommittee coldCred hotCred)
     ResignCold ->
-      checkSelfPreservation inAddress inValue inRefScript txInfoOutputs datumIn
+      checkSelfPreservation inAddress inValue txInfoOutputs datumIn
         && checkMultiSig (membershipUsers datumIn) txInfoSignatories
         && checkCertificate txInfoTxCerts (TxCertResignColdCommittee coldCred)
     ResignDelegation user ->
       checkNoCertificates txInfoTxCerts
-        && checkContinuingTx inAddress inValue inRefScript txInfoOutputs \datumOut ->
+        && checkContinuingTx inAddress inValue txInfoOutputs \datumOut ->
           checkCAConservation datumIn datumOut
             && checkMembershipConserved datumIn datumOut
             && checkResignation txInfoSignatories user delegationUsers datumIn datumOut
     ResignMembership user ->
       checkNoCertificates txInfoTxCerts
-        && checkContinuingTx inAddress inValue inRefScript txInfoOutputs \datumOut ->
+        && checkContinuingTx inAddress inValue txInfoOutputs \datumOut ->
           checkCAConservation datumIn datumOut
             && checkDelegationConserved datumIn datumOut
             && checkResignation txInfoSignatories user membershipUsers datumIn datumOut
     RotateCold ->
       checkNoCertificates txInfoTxCerts
         && checkMultiSig (membershipUsers datumIn) txInfoSignatories
-        && checkContinuingTx inAddress inValue inRefScript txInfoOutputs \datumOut ->
+        && checkContinuingTx inAddress inValue txInfoOutputs \datumOut ->
           checkCAConservation datumIn datumOut
             && checkRotation txInfoSignatories membershipUsers datumIn datumOut
             && checkRotation txInfoSignatories delegationUsers datumIn datumOut
     BurnCold ->
       checkMultiSig (membershipUsers datumIn) txInfoSignatories
         && checkNoCertificates txInfoTxCerts
-        && checkBurnAll coldNFT txInfo
+        && checkBurn coldNFT txInfo
     UpgradeCold destination ->
       checkMultiSig (membershipUsers datumIn) txInfoSignatories
         && checkNoCertificates txInfoTxCerts
-        && checkUpgrade coldNFT inAddress destination txInfoOutputs
+        && checkUpgrade coldNFT destination txInfoOutputs
 
 {-# INLINEABLE checkCAConservation #-}
 checkCAConservation :: ColdLockDatum -> ColdLockDatum -> Bool

--- a/credential-manager/src/CredentialManager/Scripts/HotCommittee.hs
+++ b/credential-manager/src/CredentialManager/Scripts/HotCommittee.hs
@@ -29,13 +29,13 @@ import PlutusTx.Prelude hiding (trace, traceIfFalse)
 -- input of the transaction.
 {-# INLINEABLE hotCommitteeScript #-}
 hotCommitteeScript :: AssetClass -> ScriptContext -> Bool
-hotCommitteeScript nft ScriptContext{..} = case scriptContextScriptInfo of
+hotCommitteeScript nft ScriptContext{scriptContextScriptInfo, scriptContextTxInfo} = case scriptContextScriptInfo of
   VotingScript _ ->
     traceIfFalse "Hot NFT not found in any input" $ any inputSpendsToken txInputs
   _ -> trace "Invalid script purpose" False
   where
     -- Checks if an input spends the correct token
-    inputSpendsToken TxInInfo{txInInfoResolved = TxOut{..}} =
+    inputSpendsToken TxInInfo{txInInfoResolved = TxOut{txOutValue}} =
       assetClassValueOf txOutValue nft == 1
     -- The list of transaction inputs being consumed in this transaction.
     txInputs = txInfoInputs scriptContextTxInfo

--- a/credential-manager/src/CredentialManager/Scripts/HotNFT.hs
+++ b/credential-manager/src/CredentialManager/Scripts/HotNFT.hs
@@ -46,9 +46,9 @@ hotNFTScript
   -> ScriptContext
   -> Bool
 hotNFTScript coldNFT hotNFT hotCred =
-  checkSpendingTx hotNFT \txInfo@TxInfo{txInfoOutputs, txInfoReferenceInputs, txInfoSignatories, txInfoVotes} inAddress inValue inRefScript datumIn -> \case
+  checkSpendingTx hotNFT \txInfo@TxInfo{txInfoOutputs, txInfoReferenceInputs, txInfoSignatories, txInfoVotes} inAddress inValue datumIn -> \case
     Vote ->
-      checkSelfPreservation inAddress inValue inRefScript txInfoOutputs datumIn
+      checkSelfPreservation inAddress inValue txInfoOutputs datumIn
         && checkMultiSig (votingUsers datumIn) txInfoSignatories
         && checkVote
       where
@@ -62,7 +62,6 @@ hotNFTScript coldNFT hotNFT hotCred =
         && checkContinuingTx
           inAddress
           inValue
-          inRefScript
           txInfoOutputs
           (checkResignation txInfoSignatories user votingUsers datumIn)
     RotateHot ->
@@ -71,17 +70,16 @@ hotNFTScript coldNFT hotNFT hotCred =
         && checkContinuingTx
           inAddress
           inValue
-          inRefScript
           txInfoOutputs
           (checkRotation txInfoSignatories votingUsers datumIn)
     BurnHot ->
       signedByDelegators txInfoSignatories txInfoReferenceInputs
         && checkNoVotes txInfoVotes
-        && checkBurnAll hotNFT txInfo
+        && checkBurn hotNFT txInfo
     UpgradeHot destination ->
       signedByDelegators txInfoSignatories txInfoReferenceInputs
         && checkNoVotes txInfoVotes
-        && checkUpgrade hotNFT inAddress destination txInfoOutputs
+        && checkUpgrade hotNFT destination txInfoOutputs
   where
     signedByDelegators signatories = go
       where

--- a/credential-manager/test/CredentialManager/Scripts/ColdNFT/ResignDelegationSpec.hs
+++ b/credential-manager/test/CredentialManager/Scripts/ColdNFT/ResignDelegationSpec.hs
@@ -1,9 +1,13 @@
 module CredentialManager.Scripts.ColdNFT.ResignDelegationSpec where
 
 import CredentialManager.Api
-import CredentialManager.Gen ()
+import CredentialManager.Gen (
+  genIncorrectlyPreservedValue,
+  genNonAdaAssetClass,
+ )
 import CredentialManager.Scripts.ColdNFT
 import CredentialManager.Scripts.ColdNFT.RotateColdSpec (updateDatum)
+import CredentialManager.Scripts.ColdNFTSpec (importanceSampleScriptValue)
 import Data.Foldable (Foldable (..))
 import Data.Function (on)
 import Data.List (nub)
@@ -235,7 +239,7 @@ invariantRD8MultipleSelfOutputs args@ValidArgs{..} =
 invariantRD9ValueNotPreserved :: ValidArgs -> Property
 invariantRD9ValueNotPreserved args@ValidArgs{..} =
   forAllValidScriptContexts args \_ _ ctx -> do
-    newValue <- arbitrary `suchThat` (/= resignDelegationValue)
+    newValue <- genIncorrectlyPreservedValue resignDelegationValue
     let modifyValue TxOut{..}
           | txOutAddress == resignDelegationScriptAddress =
               TxOut{txOutValue = newValue, ..}
@@ -454,12 +458,13 @@ instance Arbitrary ValidArgs where
         [ (,) <$> listOf1 arbitrary <*> arbitrary
         , (,) <$> arbitrary <*> listOf1 arbitrary
         ]
-    ValidArgs
+    coldNFT <- genNonAdaAssetClass
+    resignDelegationValue <- importanceSampleScriptValue True coldNFT
+    ValidArgs coldNFT
       <$> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary
-      <*> arbitrary
+      <*> pure resignDelegationValue
       <*> arbitrary `suchThat` (`notElem` membershipPre <> membershipPost)
       <*> arbitrary
       <*> arbitrary

--- a/credential-manager/test/CredentialManager/Scripts/ColdNFTSpec.hs
+++ b/credential-manager/test/CredentialManager/Scripts/ColdNFTSpec.hs
@@ -1,16 +1,25 @@
+{-# OPTIONS_GHC -Wno-unused-imports #-}
+
 module CredentialManager.Scripts.ColdNFTSpec where
 
 import Control.Exception (evaluate)
 import CredentialManager.Api
-import CredentialManager.Gen (mkValue)
+import CredentialManager.Gen (genTxInfoMintForNFTBurn, mkValue)
 import CredentialManager.Scripts.ColdNFT
-import Data.Foldable (Foldable (..))
+import Data.Foldable (Foldable (..), for_)
 import Data.Function (on)
-import Data.List (nub, nubBy)
+import Data.Functor ((<&>))
+import Data.List (elemIndex, findIndex, nub, nubBy)
 import qualified Data.Map as Map
+import Data.Maybe (fromMaybe)
+import Debug.Trace (trace)
 import GHC.Generics (Generic)
 import GHC.IO (catchAny, unsafePerformIO)
-import PlutusLedgerApi.V1.Value (AssetClass (..), assetClassValueOf)
+import PlutusLedgerApi.V1.Value (
+  AssetClass (..),
+  assetClassValue,
+  assetClassValueOf,
+ )
 import PlutusLedgerApi.V3 (
   Address (..),
   ColdCommitteeCredential,
@@ -30,6 +39,7 @@ import PlutusLedgerApi.V3 (
   TxOut (..),
   Value,
  )
+import PlutusTx.Monoid (Group (inv))
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
@@ -56,6 +66,12 @@ spec = do
   prop
     "Invariant 6: Valid transitions don't change the CA"
     invariant6CAPreservation
+  prop
+    "Invariant 7: Cold NFT is not present in own input"
+    invariant7TokenNotPresentInOwnInput
+  prop
+    "Invariant 8: Valid transitions preserve reference script"
+    invariant8ReferenceScriptPreservation
 
 invariant1BadPurpose :: ScriptArgs -> Property
 invariant1BadPurpose args@ScriptArgs{..} =
@@ -96,6 +112,81 @@ invariant5DelegationNonempty args =
 invariant6CAPreservation :: ScriptArgs -> Property
 invariant6CAPreservation args@ScriptArgs{..} =
   forAllValidTransitions args \_ -> on (===) certificateAuthority datum
+
+invariant7TokenNotPresentInOwnInput :: ScriptArgs -> Property
+invariant7TokenNotPresentInOwnInput args@ScriptArgs{..} =
+  forAllScriptContexts True args \ctx ->
+    wrapColdNFTScript coldNFT coldCredential ctx ==> do
+      let genIx len =
+            if len == 0
+              then pure Nothing
+              else
+                frequency
+                  [ (len - 1, Just <$> choose (0, len - 1))
+                  , (1, pure Nothing)
+                  ]
+          genInputIx = do
+            let otherInputsNumber = (length . txInfoInputs . scriptContextTxInfo $ ctx) - 1
+            genIx otherInputsNumber
+          genOutputIx = do
+            let otherOutputsNumber = (length . txInfoOutputs . scriptContextTxInfo $ ctx) - 1
+            genIx otherOutputsNumber
+          gen = (,) <$> genInputIx <*> genOutputIx
+
+      forAll gen \(possibleNewNFTInputTx, possibleNewNFTOutputTx) -> do
+        let ScriptContext{..} = ctx
+            TxInfo{txInfoInputs = inputs, txInfoOutputs = outputs} = scriptContextTxInfo
+            removeColdNFTFromOutput txOut@(TxOut{txOutValue}) =
+              txOut
+                { txOutValue =
+                    txOutValue
+                      <> inv (assetClassValue coldNFT (assetClassValueOf txOutValue coldNFT))
+                }
+            removeColdNFTFromInput txInInfo@TxInInfo{txInInfoResolved = txOut} = do
+              txInInfo{txInInfoResolved = removeColdNFTFromOutput txOut}
+            input' = removeColdNFTFromInput scriptInput
+            inputs' =
+              inputs <&> \input ->
+                if input == scriptInput
+                  then input'
+                  else input
+            output' = removeColdNFTFromOutput <$> scriptOutput
+            outputs' =
+              outputs <&> \output ->
+                if Just output == scriptOutput
+                  then fromMaybe output output'
+                  else output
+            addColdNFTToOutput txOut@(TxOut{txOutValue}) =
+              txOut{txOutValue = txOutValue <> assetClassValue coldNFT 1}
+            addColdNFTToInput txInInfo@TxInInfo{txInInfoResolved = txOut} = do
+              txInInfo{txInInfoResolved = addColdNFTToOutput txOut}
+            tweakElemSkipping :: forall a. Int -> Int -> [a] -> (a -> a) -> [a]
+            tweakElemSkipping ignoredIx targetIx elems f = do
+              let targetIx' = if targetIx < ignoredIx then targetIx else targetIx + 1
+              flip map (zip [0 ..] elems) \(i, e) ->
+                if i == targetIx'
+                  then f e
+                  else e
+            inputs'' = fromMaybe inputs' do
+              targetIx <- possibleNewNFTInputTx
+              ignoredIx <- elemIndex scriptInput inputs'
+              pure $ tweakElemSkipping ignoredIx targetIx inputs' addColdNFTToInput
+            outputs'' = fromMaybe outputs' do
+              targetIx <- possibleNewNFTOutputTx
+              ignoredIx <- output' >>= flip elemIndex outputs'
+              pure $ tweakElemSkipping ignoredIx targetIx outputs' addColdNFTToOutput
+            ctx' =
+              ScriptContext
+                { scriptContextTxInfo =
+                    scriptContextTxInfo{txInfoInputs = inputs'', txInfoOutputs = outputs''}
+                , ..
+                }
+         in wrapColdNFTScript coldNFT coldCredential ctx' === False
+
+invariant8ReferenceScriptPreservation :: ScriptArgs -> Property
+invariant8ReferenceScriptPreservation args@ScriptArgs{..} =
+  forAllValidTransitions args \output _ ->
+    on (===) txOutReferenceScript (txInInfoResolved scriptInput) output
 
 forAllValidTransitions
   :: (Testable prop) => ScriptArgs -> (TxOut -> ColdLockDatum -> prop) -> Property
@@ -282,12 +373,15 @@ forAllScriptContexts onlyValid ScriptArgs{..} = forAllShrink gen shrink'
         Just output -> do
           extraOutputs <- importanceSampleExtraOutputs onlyValid output
           shuffle $ output : extraOutputs
+      mint <- case redeemer of
+        BurnCold -> genTxInfoMintForNFTBurn coldNFT
+        _ -> arbitrary
       txInfo <-
         TxInfo inputs
           <$> arbitrary
           <*> pure outputs
           <*> arbitrary
-          <*> arbitrary
+          <*> pure mint
           <*> pure certs
           <*> arbitrary
           <*> arbitrary
@@ -432,7 +526,9 @@ importanceSampleScriptOutput onlyValid TxOut{..} outDatum =
     <*> importanceSampleArbitrary
       onlyValid
       (pure $ OutputDatum $ Datum $ toBuiltinData outDatum)
-    <*> arbitrary
+    <*> importanceSampleArbitrary
+      onlyValid
+      (pure txOutReferenceScript)
 
 importanceSampleArbitrary :: (Arbitrary a) => Bool -> Gen a -> Gen a
 importanceSampleArbitrary True important = important

--- a/credential-manager/test/CredentialManager/Scripts/ColdNFTSpec.hs
+++ b/credential-manager/test/CredentialManager/Scripts/ColdNFTSpec.hs
@@ -69,9 +69,6 @@ spec = do
   prop
     "Invariant 7: Cold NFT is not present in own input"
     invariant7TokenNotPresentInOwnInput
-  prop
-    "Invariant 8: Valid transitions preserve reference script"
-    invariant8ReferenceScriptPreservation
 
 invariant1BadPurpose :: ScriptArgs -> Property
 invariant1BadPurpose args@ScriptArgs{..} =
@@ -182,11 +179,6 @@ invariant7TokenNotPresentInOwnInput args@ScriptArgs{..} =
                 , ..
                 }
          in wrapColdNFTScript coldNFT coldCredential ctx' === False
-
-invariant8ReferenceScriptPreservation :: ScriptArgs -> Property
-invariant8ReferenceScriptPreservation args@ScriptArgs{..} =
-  forAllValidTransitions args \output _ ->
-    on (===) txOutReferenceScript (txInInfoResolved scriptInput) output
 
 forAllValidTransitions
   :: (Testable prop) => ScriptArgs -> (TxOut -> ColdLockDatum -> prop) -> Property

--- a/credential-manager/test/CredentialManager/Scripts/HotNFT/UpgradeHotSpec.hs
+++ b/credential-manager/test/CredentialManager/Scripts/HotNFT/UpgradeHotSpec.hs
@@ -1,8 +1,14 @@
 module CredentialManager.Scripts.HotNFT.UpgradeHotSpec where
 
 import CredentialManager.Api
-import CredentialManager.Gen (Fraction (..))
-import CredentialManager.Scripts.ColdNFTSpec (nonDelegationSigners)
+import CredentialManager.Gen (
+  Fraction (..),
+  genNonAdaAssetClass,
+ )
+import CredentialManager.Scripts.ColdNFTSpec (
+  importanceSampleScriptValue,
+  nonDelegationSigners,
+ )
 import CredentialManager.Scripts.HotNFT
 import CredentialManager.Scripts.HotNFTSpec (hasToken)
 import Data.Foldable (Foldable (..))
@@ -57,6 +63,9 @@ spec = do
   prop
     "Invariant UH6: UpgradeHot fails if token sent to wrong address"
     invariantUH6WrongAddress
+  prop
+    "Invariant UH7: UpgradeHot fails if upgrades to the same script"
+    invariantUH7SameScript
   describe "ValidArgs" do
     prop "alwaysValid" \args@ValidArgs{..} ->
       forAllValidScriptContexts args \coldNFT hotNFT _ _ _ ctx ->
@@ -187,6 +196,35 @@ invariantUH6WrongAddress args@ValidArgs{..} =
     let ctx' =
           ctx
             { scriptContextTxInfo =
+                (scriptContextTxInfo ctx)
+                  { txInfoOutputs = outputs'
+                  }
+            }
+    pure $
+      counterexample ("Context: " <> show ctx') $
+        hotNFTScript coldNFT hotNFT upgradeHotCredential ctx' === False
+
+invariantUH7SameScript :: ValidArgs -> Property
+invariantUH7SameScript args@ValidArgs{..} =
+  forAllValidScriptContexts args \coldNFT hotNFT _ _ _ ctx -> do
+    let destinationScriptCredential = case addressCredential upgradeScriptAddress of
+          ScriptCredential source -> source
+          _ -> error "ValidArgs should have a script address as a source"
+    destinationStakingCredential <- arbitrary
+    let destination =
+          Address
+            (ScriptCredential destinationScriptCredential)
+            destinationStakingCredential
+        tweakAddress TxOut{..}
+          | addressCredential txOutAddress == ScriptCredential upgradeDestination = do
+              pure TxOut{txOutAddress = destination, ..}
+          | otherwise = pure TxOut{..}
+    outputs' <- traverse tweakAddress $ txInfoOutputs $ scriptContextTxInfo ctx
+    let redeemer = UpgradeHot destinationScriptCredential
+        ctx' =
+          ctx
+            { scriptContextRedeemer = Redeemer $ toBuiltinData redeemer
+            , scriptContextTxInfo =
                 (scriptContextTxInfo ctx)
                   { txInfoOutputs = outputs'
                   }
@@ -349,16 +387,21 @@ data ValidArgs = ValidArgs
 instance Arbitrary ValidArgs where
   arbitrary = do
     destination <- arbitrary
-    ValidArgs
+    scriptAddress <-
+      arbitrary `suchThat` \addr -> case addressCredential addr of
+        (ScriptCredential source) -> source /= destination
+        _ -> False
+    coldNFT <- genNonAdaAssetClass
+    hotNFT <- genNonAdaAssetClass `suchThat` (/= coldNFT)
+    upgradeValue <- importanceSampleScriptValue True hotNFT
+    ValidArgs hotNFT coldNFT
       <$> arbitrary
-      <*> arbitrary
-      <*> arbitrary
       <*> pure destination
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary
-      <*> arbitrary `suchThat` ((/= ScriptCredential destination) . addressCredential)
-      <*> arbitrary
+      <*> pure scriptAddress
+      <*> pure upgradeValue
       <*> arbitrary
       <*> arbitrary
       <*> arbitrary

--- a/credential-manager/test/CredentialManager/Scripts/HotNFTSpec.hs
+++ b/credential-manager/test/CredentialManager/Scripts/HotNFTSpec.hs
@@ -70,9 +70,6 @@ spec = do
   prop
     "Invariant 5: Hot NFT is not present in own input"
     invariant5TokenNotPresentInOwnInput
-  prop
-    "Invariant 6: Valid transitions preserve reference script"
-    invariant6ReferenceScriptPreservation
 
 invariant1BadPurpose :: ScriptArgs -> Property
 invariant1BadPurpose args@ScriptArgs{..} =
@@ -173,11 +170,6 @@ invariant5TokenNotPresentInOwnInput args@ScriptArgs{..} =
                 , ..
                 }
          in wrapHotNFTScript coldNFT hotNFT hotCredential ctx' === False
-
-invariant6ReferenceScriptPreservation :: ScriptArgs -> Property
-invariant6ReferenceScriptPreservation args@ScriptArgs{..} =
-  forAllValidTransitions args \output _ ->
-    on (===) txOutReferenceScript (txInInfoResolved scriptInput) output
 
 wrapHotNFTScript
   :: AssetClass

--- a/doc/read-the-docs-site/orchestrator-cli/upgrade.rst
+++ b/doc/read-the-docs-site/orchestrator-cli/upgrade.rst
@@ -12,6 +12,7 @@ Step 1: Upgrading the Hot NFT
 .. warning::
    If you need to upgrade both scripts, you should upgrade the hot script before you upgrade the cold script.
    If the cold script datum format changes, you won't be able to upgrade the hot script because it won't be able to decode the datum to get the delegation group.
+   Therefore, upgrading the cold script usually involved upgrading the hot script to a version that can decode the new cold datum format, and this must be done first.
 
 First we need a script to send it to. For demonstration purposes, we're going to send it to an always true native script.
 

--- a/doc/read-the-docs-site/system-overview/cold-nft.rst
+++ b/doc/read-the-docs-site/system-overview/cold-nft.rst
@@ -21,8 +21,8 @@ Rules
 The script enforces the following rules unconditionally:
 
 * The purpose of the script execution must be `Spending`.
-
 * The UTXO being spent must be in the transaction's inputs (this will always be the case when the script is invoked by a properly implemented ledger layer).
+* The UTXO being spent should contain inline datum.
 
 The script enforces the following additional rules depending on the redeemer:
 
@@ -126,9 +126,15 @@ Rules for ``UpgradeCold`` actions
 If the redeemer is an ``UpgradeCold`` action:
 
 * The transaction has been signed by a majority of users from the **membership group** defined in the input datum.
+* The transaction includes an input at current script address that holds 1 cold NFT.
+* The destination script hash is different than the current script hash.
 * 1 cold NFT is sent to the upgrade destination script.
-* No other outputs contain the cold NFT.
 * The transaction does not contain any certificates.
+
+.. warning::
+    Before updating the cold script, it's critical to upgrade the hot locking script, especially if the cold datum structure changes. Upgrading out of order could lock the hot NFT script, as it relies heavily on the cold datum structure, including within its `UpgradeHot` function.
+
+
 
 Datum
 -----

--- a/doc/read-the-docs-site/system-overview/hot-nft.rst
+++ b/doc/read-the-docs-site/system-overview/hot-nft.rst
@@ -28,6 +28,7 @@ The script enforces the following rules unconditionally:
 
 * The purpose of the script execution must be `Spending`.
 * The UTXO being spent must be in the transaction's inputs; this will always be the case when a properly implemented ledger layer invokes the script.
+* The UTXO being spent should contain inline datum.
 
 The script enforces the following additional rules depending on the redeemer:
 
@@ -101,9 +102,10 @@ If the redeemer is an ``UpgradeHot`` action:
 
 * The transaction includes a reference input that holds the cold NFT.
 * The reference input contains a valid ``ColdLockDatum``.
+* The transaction includes an input at current script address that holds 1 hot NFT.
+* The destination script hash is different than the current script hash.
 * The transaction has been signed by a majority of users from the **delegation group** defined in the reference input's datum.
 * 1 hot NFT is sent to the upgrade destination script.
-* No other outputs contain the hot NFT.
 * The transaction does not contain any certificates.
 
 Datum

--- a/flake.lock
+++ b/flake.lock
@@ -3,28 +3,11 @@
     "CHaP": {
       "flake": false,
       "locked": {
-        "lastModified": 1719950081,
-        "narHash": "sha256-RBuStLEj6JBd1ouBRa8W0vb/X32TD49DmTvBtTIjy1c=",
+        "lastModified": 1721831314,
+        "narHash": "sha256-I1j5HPSbbh3l1D0C9oP/59YB4e+64K9NDRl7ueD1c/Y=",
         "owner": "intersectmbo",
         "repo": "cardano-haskell-packages",
-        "rev": "c5fb42c338a64c2eda832ecea7a5b354c971a5e5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "intersectmbo",
-        "ref": "repo",
-        "repo": "cardano-haskell-packages",
-        "type": "github"
-      }
-    },
-    "CHaP_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1719971647,
-        "narHash": "sha256-Q/u1ZklzmymTSSY6/F48rGsWewVYf108torqR9+nFJU=",
-        "owner": "intersectmbo",
-        "repo": "cardano-haskell-packages",
-        "rev": "bfd6987c14410757c6cde47e6c45621e9664347f",
+        "rev": "8815ee7598bc39a02db8896b788f69accf892790",
         "type": "github"
       },
       "original": {
@@ -51,22 +34,6 @@
       }
     },
     "HTTP_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1451647621,
-        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
-        "owner": "phadej",
-        "repo": "HTTP",
-        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
-        "type": "github"
-      },
-      "original": {
-        "owner": "phadej",
-        "repo": "HTTP",
-        "type": "github"
-      }
-    },
-    "HTTP_3": {
       "flake": false,
       "locked": {
         "lastModified": 1451647621,
@@ -115,23 +82,6 @@
     "blst": {
       "flake": false,
       "locked": {
-        "lastModified": 1656163412,
-        "narHash": "sha256-xero1aTe2v4IhWIJaEDUsVDOfE77dOV5zKeHWntHogY=",
-        "owner": "supranational",
-        "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
-        "type": "github"
-      },
-      "original": {
-        "owner": "supranational",
-        "repo": "blst",
-        "rev": "03b5124029979755c752eec45f3c29674b558446",
-        "type": "github"
-      }
-    },
-    "blst_2": {
-      "flake": false,
-      "locked": {
         "lastModified": 1691598027,
         "narHash": "sha256-oqljy+ZXJAXEB/fJtmB8rlAr4UXM+Z2OkDa20gpILNA=",
         "owner": "supranational",
@@ -146,7 +96,7 @@
         "type": "github"
       }
     },
-    "blst_3": {
+    "blst_2": {
       "flake": false,
       "locked": {
         "lastModified": 1691598027,
@@ -197,23 +147,6 @@
         "type": "github"
       }
     },
-    "cabal-32_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
     "cabal-34": {
       "flake": false,
       "locked": {
@@ -232,23 +165,6 @@
       }
     },
     "cabal-34_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1645834128,
-        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.4",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-34_3": {
       "flake": false,
       "locked": {
         "lastModified": 1645834128,
@@ -299,23 +215,6 @@
         "type": "github"
       }
     },
-    "cabal-36_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1669081697,
-        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.6",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
     "call-flake": {
       "locked": {
         "lastModified": 1687380775,
@@ -333,7 +232,7 @@
     },
     "cardano-automation": {
       "inputs": {
-        "flake-utils": "flake-utils_2",
+        "flake-utils": "flake-utils",
         "haskellNix": [
           "cardano-node",
           "haskellNix"
@@ -358,37 +257,9 @@
         "type": "github"
       }
     },
-    "cardano-cli": {
-      "inputs": {
-        "CHaP": "CHaP",
-        "flake-utils": "flake-utils",
-        "haskellNix": "haskellNix",
-        "incl": "incl",
-        "iohkNix": "iohkNix",
-        "nixpkgs": [
-          "cardano-cli",
-          "haskellNix",
-          "nixpkgs-unstable"
-        ]
-      },
-      "locked": {
-        "lastModified": 1720520277,
-        "narHash": "sha256-9kJyPvW5gWQcbpilMl1kxycj2BHT+Pqz28niPrv/WKo=",
-        "owner": "IntersectMBO",
-        "repo": "cardano-cli",
-        "rev": "33059eeb081b7c603f4e850797a9142f2ae504fc",
-        "type": "github"
-      },
-      "original": {
-        "owner": "IntersectMBO",
-        "ref": "cardano-cli-9.0.0.1",
-        "repo": "cardano-cli",
-        "type": "github"
-      }
-    },
     "cardano-mainnet-mirror": {
       "inputs": {
-        "nixpkgs": "nixpkgs_6"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1642701714,
@@ -407,20 +278,20 @@
     },
     "cardano-node": {
       "inputs": {
-        "CHaP": "CHaP_2",
+        "CHaP": "CHaP",
         "cardano-automation": "cardano-automation",
         "cardano-mainnet-mirror": "cardano-mainnet-mirror",
         "customConfig": "customConfig",
         "em": "em",
         "empty-flake": "empty-flake",
-        "flake-compat": "flake-compat_3",
+        "flake-compat": "flake-compat_2",
         "hackageNix": "hackageNix",
-        "haskellNix": "haskellNix_2",
+        "haskellNix": "haskellNix",
         "hostNixpkgs": [
           "cardano-node",
           "nixpkgs"
         ],
-        "iohkNix": "iohkNix_2",
+        "iohkNix": "iohkNix",
         "nix2container": "nix2container_2",
         "nixpkgs": [
           "cardano-node",
@@ -432,16 +303,16 @@
         "utils": "utils_2"
       },
       "locked": {
-        "lastModified": 1720029730,
-        "narHash": "sha256-ESE5/7XzXeIZldkYPbMd8CoMKQo9ghY1vOkhHpOj0K4=",
+        "lastModified": 1721843629,
+        "narHash": "sha256-F5wgRA820x16f+8c/LlEEBG0rMJIA1XWw6X0ZwX5UWs=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "2820a63dc934c6d5b5f450b6c2543b81c6476696",
+        "rev": "176f99e51155cb3eaa0711db1c3c969d67438958",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "9.0.0",
+        "ref": "9.1.0",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -463,22 +334,6 @@
       }
     },
     "cardano-shell_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1608537748,
-        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "type": "github"
-      }
-    },
-    "cardano-shell_3": {
       "flake": false,
       "locked": {
         "lastModified": 1608537748,
@@ -606,7 +461,7 @@
     },
     "easy-purescript-nix": {
       "inputs": {
-        "flake-utils": "flake-utils_7"
+        "flake-utils": "flake-utils_6"
       },
       "locked": {
         "lastModified": 1710161569,
@@ -656,23 +511,6 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1672831974,
-        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
-        "owner": "input-output-hk",
-        "repo": "flake-compat",
-        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "hkm/gitlab-fix",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
         "lastModified": 1650374568,
         "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
         "owner": "edolstra",
@@ -686,7 +524,7 @@
         "type": "github"
       }
     },
-    "flake-compat_3": {
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1647532380,
@@ -703,7 +541,7 @@
         "type": "github"
       }
     },
-    "flake-compat_4": {
+    "flake-compat_3": {
       "flake": false,
       "locked": {
         "lastModified": 1672831974,
@@ -720,7 +558,7 @@
         "type": "github"
       }
     },
-    "flake-compat_5": {
+    "flake-compat_4": {
       "locked": {
         "lastModified": 1696426674,
         "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
@@ -735,7 +573,7 @@
         "type": "github"
       }
     },
-    "flake-compat_6": {
+    "flake-compat_5": {
       "flake": false,
       "locked": {
         "lastModified": 1672831974,
@@ -752,7 +590,7 @@
         "type": "github"
       }
     },
-    "flake-compat_7": {
+    "flake-compat_6": {
       "flake": false,
       "locked": {
         "lastModified": 1696426674,
@@ -769,40 +607,6 @@
       }
     },
     "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1681378341,
-        "narHash": "sha256-2qUN04W6X9cHHytEsJTM41CmusifPTC0bgTtYsHSNY8=",
-        "owner": "hamishmack",
-        "repo": "flake-utils",
-        "rev": "2767bafdb189cd623354620c2dacbeca8fd58b17",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hamishmack",
-        "ref": "hkm/nested-hydraJobs",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_10": {
-      "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
       "locked": {
         "lastModified": 1667395993,
         "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
@@ -817,7 +621,7 @@
         "type": "github"
       }
     },
-    "flake-utils_3": {
+    "flake-utils_2": {
       "locked": {
         "lastModified": 1653893745,
         "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
@@ -832,7 +636,7 @@
         "type": "github"
       }
     },
-    "flake-utils_4": {
+    "flake-utils_3": {
       "locked": {
         "lastModified": 1659877975,
         "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
@@ -847,7 +651,7 @@
         "type": "github"
       }
     },
-    "flake-utils_5": {
+    "flake-utils_4": {
       "locked": {
         "lastModified": 1653893745,
         "narHash": "sha256-0jntwV3Z8//YwuOjzhV2sgJJPt+HY6KhU7VZUL0fKZQ=",
@@ -862,9 +666,9 @@
         "type": "github"
       }
     },
-    "flake-utils_6": {
+    "flake-utils_5": {
       "inputs": {
-        "systems": "systems_2"
+        "systems": "systems"
       },
       "locked": {
         "lastModified": 1710146030,
@@ -880,9 +684,9 @@
         "type": "github"
       }
     },
-    "flake-utils_7": {
+    "flake-utils_6": {
       "inputs": {
-        "systems": "systems_4"
+        "systems": "systems_3"
       },
       "locked": {
         "lastModified": 1685518550,
@@ -890,6 +694,24 @@
         "owner": "numtide",
         "repo": "flake-utils",
         "rev": "a1720a10a6cfe8234c0e93907ffe81be440f4cef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_7": {
+      "inputs": {
+        "systems": "systems_4"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
         "type": "github"
       },
       "original": {
@@ -917,15 +739,12 @@
       }
     },
     "flake-utils_9": {
-      "inputs": {
-        "systems": "systems_6"
-      },
       "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -968,23 +787,6 @@
         "type": "github"
       }
     },
-    "ghc-8.6.5-iohk_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
-        "type": "github"
-      }
-    },
     "ghc910X": {
       "flake": false,
       "locked": {
@@ -1004,44 +806,7 @@
         "url": "https://gitlab.haskell.org/ghc/ghc"
       }
     },
-    "ghc910X_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714520650,
-        "narHash": "sha256-4uz6RA1hRr0RheGNDM49a/B3jszqNNU8iHIow4mSyso=",
-        "ref": "ghc-9.10",
-        "rev": "2c6375b9a804ac7fca1e82eb6fcfc8594c67c5f5",
-        "revCount": 62663,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "ref": "ghc-9.10",
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
     "ghc911": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1714817013,
-        "narHash": "sha256-m2je4UvWfkgepMeUIiXHMwE6W+iVfUY38VDGkMzjCcc=",
-        "ref": "refs/heads/master",
-        "rev": "fc24c5cf6c62ca9e3c8d236656e139676df65034",
-        "revCount": 62816,
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      },
-      "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://gitlab.haskell.org/ghc/ghc"
-      }
-    },
-    "ghc911_2": {
       "flake": false,
       "locked": {
         "lastModified": 1714817013,
@@ -1083,7 +848,7 @@
     },
     "gomod2nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs",
         "utils": "utils"
       },
       "locked": {
@@ -1097,22 +862,6 @@
       "original": {
         "owner": "tweag",
         "repo": "gomod2nix",
-        "type": "github"
-      }
-    },
-    "hackage": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1719794527,
-        "narHash": "sha256-qHo/KumtwAzPkfLWODu/6EFY/LeK+C7iPJyAUdT8tGA=",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "da2a3bc9bd1b3dd41bb147279529c471c615fd3e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
         "type": "github"
       }
     },
@@ -1134,45 +883,45 @@
     },
     "haskell-nix": {
       "inputs": {
-        "HTTP": "HTTP_3",
-        "cabal-32": "cabal-32_3",
-        "cabal-34": "cabal-34_3",
-        "cabal-36": "cabal-36_3",
-        "cardano-shell": "cardano-shell_3",
-        "flake-compat": "flake-compat_6",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_3",
+        "HTTP": "HTTP_2",
+        "cabal-32": "cabal-32_2",
+        "cabal-34": "cabal-34_2",
+        "cabal-36": "cabal-36_2",
+        "cardano-shell": "cardano-shell_2",
+        "flake-compat": "flake-compat_5",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_2",
         "hackage": [
           "iogx",
           "hackage"
         ],
-        "hls-1.10": "hls-1.10_3",
-        "hls-2.0": "hls-2.0_3",
-        "hls-2.2": "hls-2.2_3",
-        "hls-2.3": "hls-2.3_3",
-        "hls-2.4": "hls-2.4_3",
-        "hls-2.5": "hls-2.5_3",
-        "hls-2.6": "hls-2.6_3",
-        "hls-2.7": "hls-2.7_3",
-        "hls-2.8": "hls-2.8_3",
+        "hls-1.10": "hls-1.10_2",
+        "hls-2.0": "hls-2.0_2",
+        "hls-2.2": "hls-2.2_2",
+        "hls-2.3": "hls-2.3_2",
+        "hls-2.4": "hls-2.4_2",
+        "hls-2.5": "hls-2.5_2",
+        "hls-2.6": "hls-2.6_2",
+        "hls-2.7": "hls-2.7_2",
+        "hls-2.8": "hls-2.8_2",
         "hls-2.9": "hls-2.9",
-        "hpc-coveralls": "hpc-coveralls_3",
-        "hydra": "hydra_3",
-        "iserv-proxy": "iserv-proxy_3",
+        "hpc-coveralls": "hpc-coveralls_2",
+        "hydra": "hydra_2",
+        "iserv-proxy": "iserv-proxy_2",
         "nixpkgs": [
           "iogx",
           "haskell-nix",
           "nixpkgs-unstable"
         ],
-        "nixpkgs-2003": "nixpkgs-2003_3",
-        "nixpkgs-2105": "nixpkgs-2105_3",
-        "nixpkgs-2111": "nixpkgs-2111_3",
-        "nixpkgs-2205": "nixpkgs-2205_3",
-        "nixpkgs-2211": "nixpkgs-2211_3",
-        "nixpkgs-2305": "nixpkgs-2305_3",
-        "nixpkgs-2311": "nixpkgs-2311_3",
-        "nixpkgs-unstable": "nixpkgs-unstable_3",
-        "old-ghc-nix": "old-ghc-nix_3",
-        "stackage": "stackage_3"
+        "nixpkgs-2003": "nixpkgs-2003_2",
+        "nixpkgs-2105": "nixpkgs-2105_2",
+        "nixpkgs-2111": "nixpkgs-2111_2",
+        "nixpkgs-2205": "nixpkgs-2205_2",
+        "nixpkgs-2211": "nixpkgs-2211_2",
+        "nixpkgs-2305": "nixpkgs-2305_2",
+        "nixpkgs-2311": "nixpkgs-2311_2",
+        "nixpkgs-unstable": "nixpkgs-unstable_2",
+        "old-ghc-nix": "old-ghc-nix_2",
+        "stackage": "stackage_2"
       },
       "locked": {
         "lastModified": 1720486222,
@@ -1195,11 +944,14 @@
         "cabal-34": "cabal-34",
         "cabal-36": "cabal-36",
         "cardano-shell": "cardano-shell",
-        "flake-compat": "flake-compat",
+        "flake-compat": "flake-compat_3",
         "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
         "ghc910X": "ghc910X",
         "ghc911": "ghc911",
-        "hackage": "hackage",
+        "hackage": [
+          "cardano-node",
+          "hackageNix"
+        ],
         "hls-1.10": "hls-1.10",
         "hls-2.0": "hls-2.0",
         "hls-2.2": "hls-2.2",
@@ -1213,9 +965,8 @@
         "hydra": "hydra",
         "iserv-proxy": "iserv-proxy",
         "nixpkgs": [
-          "cardano-cli",
-          "haskellNix",
-          "nixpkgs-unstable"
+          "cardano-node",
+          "nixpkgs"
         ],
         "nixpkgs-2003": "nixpkgs-2003",
         "nixpkgs-2105": "nixpkgs-2105",
@@ -1227,62 +978,6 @@
         "nixpkgs-unstable": "nixpkgs-unstable",
         "old-ghc-nix": "old-ghc-nix",
         "stackage": "stackage"
-      },
-      "locked": {
-        "lastModified": 1718701646,
-        "narHash": "sha256-068rEjRFuasfvuapoPrzrfm+b6kHGeOmFyrEwg92eBU=",
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "rev": "c019b636f237668d8bbd52c5729732bc0e4f887c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "type": "github"
-      }
-    },
-    "haskellNix_2": {
-      "inputs": {
-        "HTTP": "HTTP_2",
-        "cabal-32": "cabal-32_2",
-        "cabal-34": "cabal-34_2",
-        "cabal-36": "cabal-36_2",
-        "cardano-shell": "cardano-shell_2",
-        "flake-compat": "flake-compat_4",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk_2",
-        "ghc910X": "ghc910X_2",
-        "ghc911": "ghc911_2",
-        "hackage": [
-          "cardano-node",
-          "hackageNix"
-        ],
-        "hls-1.10": "hls-1.10_2",
-        "hls-2.0": "hls-2.0_2",
-        "hls-2.2": "hls-2.2_2",
-        "hls-2.3": "hls-2.3_2",
-        "hls-2.4": "hls-2.4_2",
-        "hls-2.5": "hls-2.5_2",
-        "hls-2.6": "hls-2.6_2",
-        "hls-2.7": "hls-2.7_2",
-        "hls-2.8": "hls-2.8_2",
-        "hpc-coveralls": "hpc-coveralls_2",
-        "hydra": "hydra_2",
-        "iserv-proxy": "iserv-proxy_2",
-        "nixpkgs": [
-          "cardano-node",
-          "nixpkgs"
-        ],
-        "nixpkgs-2003": "nixpkgs-2003_2",
-        "nixpkgs-2105": "nixpkgs-2105_2",
-        "nixpkgs-2111": "nixpkgs-2111_2",
-        "nixpkgs-2205": "nixpkgs-2205_2",
-        "nixpkgs-2211": "nixpkgs-2211_2",
-        "nixpkgs-2305": "nixpkgs-2305_2",
-        "nixpkgs-2311": "nixpkgs-2311_2",
-        "nixpkgs-unstable": "nixpkgs-unstable_2",
-        "old-ghc-nix": "old-ghc-nix_2",
-        "stackage": "stackage_2"
       },
       "locked": {
         "lastModified": 1718797200,
@@ -1355,23 +1050,6 @@
         "type": "github"
       }
     },
-    "hls-1.10_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1680000865,
-        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "1.10.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
     "hls-2.0": {
       "flake": false,
       "locked": {
@@ -1390,23 +1068,6 @@
       }
     },
     "hls-2.0_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1687698105,
-        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "783905f211ac63edf982dd1889c671653327e441",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.0.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.0_3": {
       "flake": false,
       "locked": {
         "lastModified": 1687698105,
@@ -1457,23 +1118,6 @@
         "type": "github"
       }
     },
-    "hls-2.2_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1693064058,
-        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.2.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
     "hls-2.3": {
       "flake": false,
       "locked": {
@@ -1492,23 +1136,6 @@
       }
     },
     "hls-2.3_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1695910642,
-        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.3.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.3_3": {
       "flake": false,
       "locked": {
         "lastModified": 1695910642,
@@ -1559,23 +1186,6 @@
         "type": "github"
       }
     },
-    "hls-2.4_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1699862708,
-        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.4.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
     "hls-2.5": {
       "flake": false,
       "locked": {
@@ -1594,23 +1204,6 @@
       }
     },
     "hls-2.5_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1701080174,
-        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.5.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.5_3": {
       "flake": false,
       "locked": {
         "lastModified": 1701080174,
@@ -1661,23 +1254,6 @@
         "type": "github"
       }
     },
-    "hls-2.6_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1705325287,
-        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.6.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
     "hls-2.7": {
       "flake": false,
       "locked": {
@@ -1712,23 +1288,6 @@
         "type": "github"
       }
     },
-    "hls-2.7_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1708965829,
-        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.7.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
     "hls-2.8": {
       "flake": false,
       "locked": {
@@ -1747,23 +1306,6 @@
       }
     },
     "hls-2.8_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1715153580,
-        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.8.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.8_3": {
       "flake": false,
       "locked": {
         "lastModified": 1715153580,
@@ -1829,27 +1371,11 @@
         "type": "github"
       }
     },
-    "hpc-coveralls_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1607498076,
-        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
-        "type": "github"
-      },
-      "original": {
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "type": "github"
-      }
-    },
     "hydra": {
       "inputs": {
         "nix": "nix",
         "nixpkgs": [
-          "cardano-cli",
+          "cardano-node",
           "haskellNix",
           "hydra",
           "nix",
@@ -1873,30 +1399,6 @@
       "inputs": {
         "nix": "nix_2",
         "nixpkgs": [
-          "cardano-node",
-          "haskellNix",
-          "hydra",
-          "nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1671755331,
-        "narHash": "sha256-hXsgJj0Cy0ZiCiYdW2OdBz5WmFyOMKuw4zyxKpgUKm4=",
-        "owner": "NixOS",
-        "repo": "hydra",
-        "rev": "f48f00ee6d5727ae3e488cbf9ce157460853fea8",
-        "type": "github"
-      },
-      "original": {
-        "id": "hydra",
-        "type": "indirect"
-      }
-    },
-    "hydra_3": {
-      "inputs": {
-        "nix": "nix_3",
-        "nixpkgs": [
           "iogx",
           "haskell-nix",
           "hydra",
@@ -1918,24 +1420,6 @@
       }
     },
     "incl": {
-      "inputs": {
-        "nixlib": "nixlib"
-      },
-      "locked": {
-        "lastModified": 1693483555,
-        "narHash": "sha256-Beq4WhSeH3jRTZgC1XopTSU10yLpK1nmMcnGoXO0XYo=",
-        "owner": "divnix",
-        "repo": "incl",
-        "rev": "526751ad3d1e23b07944b14e3f6b7a5948d3007b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "incl",
-        "type": "github"
-      }
-    },
-    "incl_2": {
       "inputs": {
         "nixlib": [
           "cardano-node",
@@ -1964,8 +1448,8 @@
           "CHaP"
         ],
         "easy-purescript-nix": "easy-purescript-nix",
-        "flake-compat": "flake-compat_5",
-        "flake-utils": "flake-utils_8",
+        "flake-compat": "flake-compat_4",
+        "flake-utils": "flake-utils_7",
         "hackage": [
           "cardano-node",
           "hackageNix"
@@ -1998,13 +1482,13 @@
     },
     "iohk-nix": {
       "inputs": {
-        "blst": "blst_3",
+        "blst": "blst_2",
         "nixpkgs": [
           "iogx",
           "nixpkgs"
         ],
-        "secp256k1": "secp256k1_3",
-        "sodium": "sodium_3"
+        "secp256k1": "secp256k1_2",
+        "sodium": "sodium_2"
       },
       "locked": {
         "lastModified": 1719443312,
@@ -2023,40 +1507,19 @@
     "iohkNix": {
       "inputs": {
         "blst": "blst",
-        "nixpkgs": "nixpkgs_2",
-        "secp256k1": "secp256k1",
-        "sodium": "sodium"
-      },
-      "locked": {
-        "lastModified": 1702362799,
-        "narHash": "sha256-cU8cZXNuo5GRwrSvWqdaqoW5tJ2HWwDEOvWwIVPDPmo=",
-        "owner": "input-output-hk",
-        "repo": "iohk-nix",
-        "rev": "b426fb9e0b109a9d1dd2e1476f9e0bd8bb715142",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "iohk-nix",
-        "type": "github"
-      }
-    },
-    "iohkNix_2": {
-      "inputs": {
-        "blst": "blst_2",
         "nixpkgs": [
           "cardano-node",
           "nixpkgs"
         ],
-        "secp256k1": "secp256k1_2",
-        "sodium": "sodium_2"
+        "secp256k1": "secp256k1",
+        "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1719237167,
-        "narHash": "sha256-ifW5Jfwu/iwYs0r7f8AdiWDQK+Pr1gZLz+p5u8OtOgo=",
+        "lastModified": 1721825987,
+        "narHash": "sha256-PPcma4tjozwXJAWf+YtHUQUulmxwulVlwSQzKItx/n8=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "577f4d5072945a88dda6f5cfe205e6b4829a0423",
+        "rev": "eb61f2c14e1f610ec59117ad40f8690cddbf80cb",
         "type": "github"
       },
       "original": {
@@ -2083,23 +1546,6 @@
       }
     },
     "iserv-proxy_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1717479972,
-        "narHash": "sha256-7vE3RQycHI1YT9LHJ1/fUaeln2vIpYm6Mmn8FTpYeVo=",
-        "owner": "stable-haskell",
-        "repo": "iserv-proxy",
-        "rev": "2ed34002247213fc435d0062350b91bab920626e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "stable-haskell",
-        "ref": "iserv-syms",
-        "repo": "iserv-proxy",
-        "type": "github"
-      }
-    },
-    "iserv-proxy_3": {
       "flake": false,
       "locked": {
         "lastModified": 1717479972,
@@ -2163,22 +1609,6 @@
         "type": "github"
       }
     },
-    "lowdown-src_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1633514407,
-        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "kristapsdz",
-        "repo": "lowdown",
-        "type": "github"
-      }
-    },
     "mdbook-kroki-preprocessor": {
       "flake": false,
       "locked": {
@@ -2197,7 +1627,7 @@
     },
     "n2c": {
       "inputs": {
-        "flake-utils": "flake-utils_5",
+        "flake-utils": "flake-utils_4",
         "nixpkgs": [
           "cardano-node",
           "cardano-automation",
@@ -2223,7 +1653,7 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_5",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
@@ -2243,7 +1673,7 @@
     },
     "nix-nomad": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat",
         "flake-utils": [
           "cardano-node",
           "cardano-automation",
@@ -2281,8 +1711,8 @@
     },
     "nix2container": {
       "inputs": {
-        "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_4"
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
       },
       "locked": {
         "lastModified": 1658567952,
@@ -2300,8 +1730,8 @@
     },
     "nix2container_2": {
       "inputs": {
-        "flake-utils": "flake-utils_6",
-        "nixpkgs": "nixpkgs_8"
+        "flake-utils": "flake-utils_5",
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1712990762,
@@ -2319,8 +1749,8 @@
     },
     "nix2container_3": {
       "inputs": {
-        "flake-utils": "flake-utils_9",
-        "nixpkgs": "nixpkgs_11"
+        "flake-utils": "flake-utils_8",
+        "nixpkgs": "nixpkgs_9"
       },
       "locked": {
         "lastModified": 1712990762,
@@ -2339,29 +1769,8 @@
     "nix_2": {
       "inputs": {
         "lowdown-src": "lowdown-src_2",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_8",
         "nixpkgs-regression": "nixpkgs-regression_2"
-      },
-      "locked": {
-        "lastModified": 1661606874,
-        "narHash": "sha256-9+rpYzI+SmxJn+EbYxjGv68Ucp22bdFUSy/4LkHkkDQ=",
-        "owner": "NixOS",
-        "repo": "nix",
-        "rev": "11e45768b34fdafdcf019ddbd337afa16127ff0f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "2.11.0",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
-    "nix_3": {
-      "inputs": {
-        "lowdown-src": "lowdown-src_3",
-        "nixpkgs": "nixpkgs_10",
-        "nixpkgs-regression": "nixpkgs-regression_3"
       },
       "locked": {
         "lastModified": 1661606874,
@@ -2418,8 +1827,8 @@
     },
     "nixgl": {
       "inputs": {
-        "flake-utils": "flake-utils_10",
-        "nixpkgs": "nixpkgs_13"
+        "flake-utils": "flake-utils_9",
+        "nixpkgs": "nixpkgs_11"
       },
       "locked": {
         "lastModified": 1713543440,
@@ -2435,33 +1844,18 @@
         "type": "github"
       }
     },
-    "nixlib": {
-      "locked": {
-        "lastModified": 1667696192,
-        "narHash": "sha256-hOdbIhnpWvtmVynKcsj10nxz9WROjZja+1wRAJ/C9+s=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "babd9cd2ca6e413372ed59fbb1ecc3c3a5fd3e5b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "lastModified": 1653581809,
+        "narHash": "sha256-Uvka0V5MTGbeOfWte25+tfRL3moECDh1VwokWSZUdoY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "rev": "83658b28fe638a170a19b8933aa008b30640fbd1",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05-small",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -2483,22 +1877,6 @@
       }
     },
     "nixpkgs-2003_2": {
-      "locked": {
-        "lastModified": 1620055814,
-        "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1db42b7fe3878f3f5f7a4f2dc210772fd080e205",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-20.03-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2003_3": {
       "locked": {
         "lastModified": 1620055814,
         "narHash": "sha256-8LEHoYSJiL901bTMVatq+rf8y7QtWuZhwwpKE2fyaRY=",
@@ -2546,22 +1924,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-2105_3": {
-      "locked": {
-        "lastModified": 1659914493,
-        "narHash": "sha256-lkA5X3VNMKirvA+SUzvEhfA7XquWLci+CGi505YFAIs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "022caabb5f2265ad4006c1fa5b1ebe69fb0c3faf",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-2111": {
       "locked": {
         "lastModified": 1659446231,
@@ -2579,22 +1941,6 @@
       }
     },
     "nixpkgs-2111_2": {
-      "locked": {
-        "lastModified": 1659446231,
-        "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "eabc38219184cc3e04a974fe31857d8e0eac098d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-21.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2111_3": {
       "locked": {
         "lastModified": 1659446231,
         "narHash": "sha256-hekabNdTdgR/iLsgce5TGWmfIDZ86qjPhxDg/8TlzhE=",
@@ -2642,22 +1988,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-2205_3": {
-      "locked": {
-        "lastModified": 1685573264,
-        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-2211": {
       "locked": {
         "lastModified": 1688392541,
@@ -2675,22 +2005,6 @@
       }
     },
     "nixpkgs-2211_2": {
-      "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-22.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2211_3": {
       "locked": {
         "lastModified": 1688392541,
         "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
@@ -2738,22 +2052,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-2305_3": {
-      "locked": {
-        "lastModified": 1701362232,
-        "narHash": "sha256-GVdzxL0lhEadqs3hfRLuj+L1OJFGiL/L7gCcelgBlsw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d2332963662edffacfddfad59ff4f709dde80ffe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-23.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-2311": {
       "locked": {
         "lastModified": 1701386440,
@@ -2786,22 +2084,6 @@
         "type": "github"
       }
     },
-    "nixpkgs-2311_3": {
-      "locked": {
-        "lastModified": 1701386440,
-        "narHash": "sha256-xI0uQ9E7JbmEy/v8kR9ZQan6389rHug+zOtZeZFiDJk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "293822e55ec1872f715a66d0eda9e592dc14419f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-23.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs-regression": {
       "locked": {
         "lastModified": 1643052045,
@@ -2819,22 +2101,6 @@
       }
     },
     "nixpkgs-regression_2": {
-      "locked": {
-        "lastModified": 1643052045,
-        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
-        "type": "github"
-      }
-    },
-    "nixpkgs-regression_3": {
       "locked": {
         "lastModified": 1643052045,
         "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
@@ -2914,54 +2180,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-unstable_3": {
-      "locked": {
-        "lastModified": 1694822471,
-        "narHash": "sha256-6fSDCj++lZVMZlyqOe9SIOL8tYSBz1bI8acwovRwoX8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "47585496bcb13fb72e4a90daeea2f434e2501998",
-        "type": "github"
-      }
-    },
     "nixpkgs_10": {
-      "locked": {
-        "lastModified": 1657693803,
-        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.05-small",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_11": {
-      "locked": {
-        "lastModified": 1712920918,
-        "narHash": "sha256-1yxFvUcJfUphK9V91KufIQom7gCsztza0H4Rz2VCWUU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "92323443a56f4e9fc4e4b712e3119f66d0969297",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_12": {
       "locked": {
         "lastModified": 1719082008,
         "narHash": "sha256-jHJSUH619zBQ6WdC21fFAlDxHErKVDJ5fpN0Hgx4sjs=",
@@ -2977,7 +2196,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_13": {
+    "nixpkgs_11": {
       "locked": {
         "lastModified": 1660551188,
         "narHash": "sha256-a1LARMMYQ8DPx1BgoI/UN4bXe12hhZkCNqdxNi6uS0g=",
@@ -2994,38 +2213,6 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1688392541,
-        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "release-22.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1653581809,
-        "narHash": "sha256-Uvka0V5MTGbeOfWte25+tfRL3moECDh1VwokWSZUdoY=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "83658b28fe638a170a19b8933aa008b30640fbd1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
         "lastModified": 1654807842,
         "narHash": "sha256-ADymZpr6LuTEBXcy6RtFHcUZdjKTBRTMYwu19WOx17E=",
         "owner": "NixOS",
@@ -3039,7 +2226,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1665087388,
         "narHash": "sha256-FZFPuW9NWHJteATOf79rZfwfRn5fE0wi9kRzvGfDHPA=",
@@ -3055,7 +2242,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1642336556,
         "narHash": "sha256-QSPPbFEwy0T0DrIuSzAACkaANPQaR1lZR/nHZGz9z04=",
@@ -3069,7 +2256,7 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1657693803,
         "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
@@ -3085,7 +2272,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1712920918,
         "narHash": "sha256-1yxFvUcJfUphK9V91KufIQom7gCsztza0H4Rz2VCWUU=",
@@ -3100,7 +2287,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_9": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1708343346,
         "narHash": "sha256-qlzHvterVRzS8fS0ophQpkh0rqw0abijHEOAKm0HmV0=",
@@ -3112,6 +2299,37 @@
       "original": {
         "owner": "nixos",
         "ref": "release-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_8": {
+      "locked": {
+        "lastModified": 1657693803,
+        "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "365e1b3a859281cf11b94f87231adeabbdd878a2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.05-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1712920918,
+        "narHash": "sha256-1yxFvUcJfUphK9V91KufIQom7gCsztza0H4Rz2VCWUU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "92323443a56f4e9fc4e4b712e3119f66d0969297",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -3149,23 +2367,6 @@
       }
     },
     "old-ghc-nix_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1631092763,
-        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
-        "owner": "angerman",
-        "repo": "old-ghc-nix",
-        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "angerman",
-        "ref": "master",
-        "repo": "old-ghc-nix",
-        "type": "github"
-      }
-    },
-    "old-ghc-nix_3": {
       "flake": false,
       "locked": {
         "lastModified": 1631092763,
@@ -3247,9 +2448,9 @@
     },
     "pre-commit-hooks-nix": {
       "inputs": {
-        "flake-compat": "flake-compat_7",
+        "flake-compat": "flake-compat_6",
         "gitignore": "gitignore",
-        "nixpkgs": "nixpkgs_12",
+        "nixpkgs": "nixpkgs_10",
         "nixpkgs-stable": "nixpkgs-stable_2"
       },
       "locked": {
@@ -3268,7 +2469,6 @@
     },
     "root": {
       "inputs": {
-        "cardano-cli": "cardano-cli",
         "cardano-node": "cardano-node",
         "iogx": "iogx",
         "nixgl": "nixgl",
@@ -3296,23 +2496,6 @@
       }
     },
     "secp256k1_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1683999695,
-        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
-        "owner": "bitcoin-core",
-        "repo": "secp256k1",
-        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
-        "type": "github"
-      },
-      "original": {
-        "owner": "bitcoin-core",
-        "ref": "v0.3.2",
-        "repo": "secp256k1",
-        "type": "github"
-      }
-    },
-    "secp256k1_3": {
       "flake": false,
       "locked": {
         "lastModified": 1683999695,
@@ -3363,23 +2546,6 @@
         "type": "github"
       }
     },
-    "sodium_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1675156279,
-        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
-        "owner": "input-output-hk",
-        "repo": "libsodium",
-        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "libsodium",
-        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
-        "type": "github"
-      }
-    },
     "sphinxcontrib-haddock": {
       "flake": false,
       "locked": {
@@ -3399,22 +2565,6 @@
     "stackage": {
       "flake": false,
       "locked": {
-        "lastModified": 1718670223,
-        "narHash": "sha256-/OQ1pAA8prPpajKkS3G+FU9CwSBM9Gk8SsrCotnSu/o=",
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "rev": "eec12e078945857d1ee4fc622fe032148ab9edff",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "type": "github"
-      }
-    },
-    "stackage_2": {
-      "flake": false,
-      "locked": {
         "lastModified": 1718756571,
         "narHash": "sha256-8rL8viTbuE9/yV1of6SWp2tHmhVMD2UmkOfmN5KDbKg=",
         "owner": "input-output-hk",
@@ -3428,7 +2578,7 @@
         "type": "github"
       }
     },
-    "stackage_3": {
+    "stackage_2": {
       "flake": false,
       "locked": {
         "lastModified": 1720484587,
@@ -3449,7 +2599,7 @@
         "blank": "blank",
         "devshell": "devshell",
         "dmerge": "dmerge",
-        "flake-utils": "flake-utils_4",
+        "flake-utils": "flake-utils_3",
         "makes": [
           "cardano-node",
           "cardano-automation",
@@ -3467,7 +2617,7 @@
         ],
         "n2c": "n2c",
         "nixago": "nixago",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_3",
         "yants": "yants"
       },
       "locked": {
@@ -3499,7 +2649,7 @@
         ],
         "dmerge": "dmerge_2",
         "haumea": "haumea",
-        "incl": "incl_2",
+        "incl": "incl",
         "lib": "lib",
         "makes": [
           "cardano-node",
@@ -3521,7 +2671,7 @@
           "std",
           "blank"
         ],
-        "nixpkgs": "nixpkgs_9",
+        "nixpkgs": "nixpkgs_7",
         "paisano": "paisano",
         "paisano-tui": "paisano-tui",
         "terranix": [
@@ -3620,21 +2770,6 @@
         "type": "github"
       }
     },
-    "systems_6": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "tullia": {
       "inputs": {
         "nix-nomad": "nix-nomad",
@@ -3677,7 +2812,7 @@
     },
     "utils_2": {
       "inputs": {
-        "systems": "systems_3"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1710146030,

--- a/flake.nix
+++ b/flake.nix
@@ -30,8 +30,7 @@
     #   url = "github:input-output-hk/haskell.nix";
     #   inputs.hackage.follows = "hackage";
     # };
-    cardano-node.url = "github:IntersectMBO/cardano-node/9.0.0";
-    cardano-cli.url = "github:IntersectMBO/cardano-cli?ref=cardano-cli-9.0.0.1";
+    cardano-node.url = "github:IntersectMBO/cardano-node/9.1.0";
   };
 
 

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -21,7 +21,7 @@ cabalProject:
     pkgs.gnused
     # inputs.nixgl.packages.nixGLDefault
     inputs.cardano-node.packages.cardano-node
-    inputs.cardano-cli.packages."cardano-cli:exe:cardano-cli"
+    inputs.cardano-node.packages.cardano-cli
   ];
 
   preCommit = {

--- a/testnet/scripts/babbage/mkfiles.sh
+++ b/testnet/scripts/babbage/mkfiles.sh
@@ -6,6 +6,8 @@ set -e
 set -u
 set -o pipefail
 
+UNAME=$(uname -s)
+
 sprocket() {
   if [ "$UNAME" == "Windows_NT" ]; then
     # Named pipes names on Windows must have the structure: "\\.\pipe\PipeName"
@@ -21,7 +23,7 @@ NETWORK_MAGIC=42
 SECURITY_PARAM=10
 NUM_SPO_NODES=3
 INIT_SUPPLY=12000000
-START_TIME="$(${DATE} -d "now + 5 seconds" +%s)"
+START_TIME="$(date -d "now + 5 seconds" +%s)"
 ROOT=example
 mkdir -p "${ROOT}"
 


### PR DESCRIPTION
#### 2.3.1 Unexpected behavior

2.3.1.1 Full value conservation is too strong a requirement:
* Implementation: https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/src/CredentialManager/Scripts/Common.hs#L155
* Tests:
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/test/CredentialManager/Gen.hs#L442
  * All `Value` checks were updated - I list one two examples: one for `HotNFT` and one for `ColdNFT`:
    * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/test/CredentialManager/Scripts/ColdNFT/AuthorizeSpec.hs#L221
    * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/test/CredentialManager/Scripts/HotNFT/ResignVotingSpec.hs#L224
  
2.3.1.2 Misleading burning check in spending script:
* Implementation: https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/src/CredentialManager/Scripts/Common.hs#L231
* Tests:
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/test/CredentialManager/Scripts/ColdNFT/BurnColdSpec.hs#L107
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/test/CredentialManager/Scripts/HotNFT/BurnHotSpec.hs#L167
  
2.3.1.3 Upgrading can be done to manipulate datum in the same script
* Implementation: https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/src/CredentialManager/Scripts/Common.hs#L242
* Tests:
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/test/CredentialManager/Scripts/ColdNFT/UpgradeColdSpec.hs#L146
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/test/CredentialManager/Scripts/HotNFT/UpgradeHotSpec.hs#L207
  
2.3.1.4 NFT Script does not check for NFT presence
* Implementation: https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/src/CredentialManager/Scripts/Common.hs#L108
* Tests:
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/test/CredentialManager/Scripts/ColdNFTSpec.hs#L116
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/test/CredentialManager/Scripts/HotNFTSpec.hs#L108
  * Many scenarios were failing and all of them were updated so their corresponding `ValidArgs` provide script input with appropriate - an example:
    * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/test/CredentialManager/Scripts/ColdNFT/AuthorizeSpec.hs#L390
    
2.3.1.5 `findOutputsByCredential` could filter by address
* Implementation: https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/src/CredentialManager/Scripts/Common.hs#L150

#### 2.3.2 Unclear specification

2.3.2.1 Unchecked reference script in `checkContinuingTx`
* Implementation:
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/src/CredentialManager/Scripts/Minting.hs#L150
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/src/CredentialManager/Scripts/Common.hs#L152
* Tests:
  * Valid `ScriptArgs` generation was changed in both `ColdNFTSpec.hs` and `HotNFTSpec.hs`:
    * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/test/CredentialManager/Scripts/ColdNFTSpec.hs#L529
    * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/test/CredentialManager/Scripts/HotNFTSpec.hs#L491
  * Extra tests were added:
    * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/test/CredentialManager/Scripts/HotNFTSpec.hs#L177
    * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/test/CredentialManager/Scripts/ColdNFTSpec.hs#L186
    
2.3.2.2 NFT existence checks are too liberal
* Implementation - all corresponding checks `> 0` (or `0 <`) where turned into `== 1` - examples:
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/src/CredentialManager/Scripts/Common.hs#L108
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/src/CredentialManager/Scripts/Common.hs#L246
  
  
2.3.2.3 `checkUpgrade` function does not match its specification
* Implementation - specification was updated accordingly:
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/doc/read-the-docs-site/system-overview/cold-nft.rst#rules-for-upgradecold-actions
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/doc/read-the-docs-site/system-overview/hot-nft.rst#rules-for-upgradehot-actions

2.3.2.4 Datum upgrade requirements undocumented
* Implementation - warning section was added under `UpgradeCold` rules section:
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/doc/read-the-docs-site/system-overview/cold-nft.rst#rules-for-upgradecold-actions
  
2.3.2.5
* Implementation - inline datum requirement was added to the scripts rules lists:
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/doc/read-the-docs-site/system-overview/hot-nft.rst#rules
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/doc/read-the-docs-site/system-overview/cold-nft.rst#rules

#### 2.3.3 Code quality

2.3.3.1 Double instance of a `checkBurn` function
* Implementation:
  * `Common.checkBurn` was renamed to `Common.checkBurnAll` which checks if all tokens were burned: https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/src/CredentialManager/Scripts/Common.hs#L228
  * `Mining.checkBurn` was split into two checks:
    * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/src/CredentialManager/Scripts/Minting.hs#L106
    * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/src/CredentialManager/Scripts/Minting.hs#L112
    
2.3.3.2 `checkSpendingTx` re-implements Plutus logic
* Implementation - switched to `findOwnInput`:
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/src/CredentialManager/Scripts/Common.hs#L101
  
2.3.3.3 Unnecessary `Datum` dependency check
* Implementation - all non datum dependent checks where extracted out:
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/src/CredentialManager/Scripts/ColdNFT.hs#L40

2.3.3.4 Argument names for `checkMultiSig` are unclear
* Implemention:
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/src/CredentialManager/Scripts/Common.hs#L68
  
2.3.3.5 Unused parameter to `checkSpendingTx` callback
* Implementation:
  * https://github.com/IntersectMBO/credential-manager/blob/paluh/audit-findings/credential-manager/src/CredentialManager/Scripts/Common.hs#L88

2.3.3.6 Use of `RecordWildCards` extension
* Implementation - switched to field puns in all the on-chain code.
