### PR TITLE
Perturbing/add color to cc sign

### DIFF
--- a/credential-manager/credential-manager.cabal
+++ b/credential-manager/credential-manager.cabal
@@ -206,6 +206,7 @@ executable cc-sign
   main-is:        Main.hs
   other-modules:  Paths_credential_manager
   build-depends:
+    , ansi-terminal
     , base
     , binary
     , bitset


### PR DESCRIPTION
This update improves the user experience of the `cc-sign` CLI tool by adding ANSI color and bold formatting to highlight important information in transaction summaries (e.g., vote decisions, governance actions, anchor data). These changes make it easier to visually parse and verify what is being signed.