### PR TITLE
implement better multi vote UI

### DIFF
--- a/credential-manager/cc-sign/Main.hs
+++ b/credential-manager/cc-sign/Main.hs
@@ -504,7 +504,15 @@ summarizeVotes flags (TxBody TxBodyContent{..}) classification = do
                           <> show h
                     _ ->
                       dieIndented $ "Unexpected voter type: " <> show voter
-                  traverse_ (uncurry $ summarizeVote flags) (Map.toList votes)
+                  -- traverse_ (uncurry $ summarizeVote flags) (Map.toList votes)
+                  let voteList = Map.toList votes
+                  for_ voteList $ \(govActionId, votingProcedure) -> do
+                    System.Console.ANSI.clearScreen
+                    putStrLn "Governance Vote Review"
+                    putStrLn "======================="
+                    summarizeVote flags govActionId votingProcedure
+                    promptToProceed flags "Do you want to include this vote?"
+
                   pure True
             _ -> do
               dieIndented "Votes cast by multiple voters"

--- a/credential-manager/cc-sign/Main.hs
+++ b/credential-manager/cc-sign/Main.hs
@@ -168,7 +168,7 @@ main = do
   promptCertificates <- summarizeCertificates flags txBody classification
   when promptCertificates $ promptToProceed flags "Is this certificate correct?"
   promptVotes <- summarizeVotes flags txBody classification
-  when promptVotes $ promptToProceed flags "Are these votes correct?"
+  when promptVotes $ promptToProceed flags "Are you sure these votes are correct?"
   summarizeOutputs flags pubKeyHash classification txBody
   checkExtraTxBodyFields classification flags txBody
   summarizeSignatories flags pubKeyHash $ first (const txBody) txOrBundle
@@ -497,19 +497,16 @@ summarizeVotes flags (TxBody TxBodyContent{..}) classification = do
               | Map.null votes -> do
                   dieIndented "No votes cast"
               | otherwise -> do
-                  case voter of
-                    L.CommitteeVoter (L.ScriptHashObj (L.ScriptHash h)) ->
-                      printIndented flags $
-                        "Voting as hot credential: "
-                          <> show h
-                    _ ->
-                      dieIndented $ "Unexpected voter type: " <> show voter
-                  -- traverse_ (uncurry $ summarizeVote flags) (Map.toList votes)
                   let voteList = Map.toList votes
                   for_ voteList $ \(govActionId, votingProcedure) -> do
                     System.Console.ANSI.clearScreen
-                    putStrLn "Governance Vote Review"
-                    putStrLn "======================="
+                    case voter of
+                      L.CommitteeVoter (L.ScriptHashObj (L.ScriptHash h)) ->
+                        printIndented flags $
+                          "Voting as hot credential: "
+                            <> show h
+                      _ ->
+                        dieIndented $ "Unexpected voter type: " <> show voter
                     summarizeVote flags govActionId votingProcedure
                     promptToProceed flags "Do you want to include this vote?"
 

--- a/credential-manager/credential-manager.cabal
+++ b/credential-manager/credential-manager.cabal
@@ -1,6 +1,6 @@
 cabal-version: 3.4
 name:          credential-manager
-version:       0.1.3.0
+version:       0.1.4.0
 synopsis:
   Credential management smart contracts for members of the Cardano constitutional committee
 


### PR DESCRIPTION
This update improves the user experience of the cc-sign CLI tool by chunking import signing info to better support transactions that contain many votes (e.g., vote decisions, governance action ID, and anchor data). These changes make it easier to visually parse and verify what is being signed.

Before a transaction that contained 41 votes showed as
![image](https://github.com/user-attachments/assets/b613d0c5-7c9e-4463-9567-aa81caa5b789)
This information looks cluttered, and parsing it for verification is hard. This is because you have to scroll and tally what has been checked since all information is presented at once.

Now it shows as
![image](https://github.com/user-attachments/assets/6266714e-9dcc-4e9a-9d4a-a5c56e82febf)

After which each individual vote is presented as a chunked
![image](https://github.com/user-attachments/assets/26c05d80-90d2-4481-9ef3-53ff3293aee7)
The ending of the signing procedure is not affected by this change. That is, after the last vote is presented, the voting behaves the same as before this PR.
![image](https://github.com/user-attachments/assets/fe42bf17-e42e-4c53-8783-0ff003eed1af)
