### PR TITLE
add logging of n out m vote to cc-sign

### DIFF
--- a/credential-manager/cc-sign/Main.hs
+++ b/credential-manager/cc-sign/Main.hs
@@ -498,8 +498,10 @@ summarizeVotes flags (TxBody TxBodyContent{..}) classification = do
                   dieIndented "No votes cast"
               | otherwise -> do
                   let voteList = Map.toList votes
-                  for_ voteList $ \(govActionId, votingProcedure) -> do
+                      totalVotes = length voteList
+                  for_ (zip [1 ..] voteList) $ \(i, (govActionId, votingProcedure)) -> do
                     System.Console.ANSI.clearScreen
+                    printIndented flags $ "Vote " <> show i <> " out of " <> show totalVotes
                     case voter of
                       L.CommitteeVoter (L.ScriptHashObj (L.ScriptHash h)) ->
                         printIndented flags $


### PR DESCRIPTION
Based on user feedback, this PR implements a feature request for showing the index of the vote that is displayed. Before it showed as
<img width="2558" height="195" alt="image" src="https://github.com/user-attachments/assets/1bc971bb-e583-4c9e-a676-2b3f4230e173" />
Now it will show as
<img width="1364" height="262" alt="image" src="https://github.com/user-attachments/assets/784c219a-c3b2-46cb-9974-1aa67b40afe1" />
